### PR TITLE
Corrected source link

### DIFF
--- a/api/http_response.md
+++ b/api/http_response.md
@@ -18,7 +18,7 @@ Version 3.x
 - Alias: **http/response**
 - Definition: [https://github.com/eclipse/dirigible/issues/13](https://github.com/eclipse/dirigible/issues/13)
 - Source: [/http/v3/response.js](https://github.com/dirigiblelabs/api-v3-http/blob/master/http/v3/response.js)
-- Facade: [HttpResponseFacade](https://github.com/eclipse/dirigible/blob/master/api/api-facades/api-http/src/main/java/org/eclipse/dirigible/api/v3/http/HttpResponseFacade.java)
+- Facade: [HttpResponseFacade](https://github.com/eclipse/dirigible/blob/master/api/api-facade/api-http/src/main/java/org/eclipse/dirigible/api/v3/http/HttpResponseFacade.java)
 - Status: **alpha**
 
 


### PR DESCRIPTION
Corrected source link from
https://github.com/eclipse/dirigible/blob/master/api/api-facades
to
https://github.com/eclipse/dirigible/blob/master/api/api-facade