### PR TITLE
[Fix] Compatibility - docker.md: Docker run command made on one line

### DIFF
--- a/docs-help/docs/setup/docker.md
+++ b/docs-help/docs/setup/docker.md
@@ -26,9 +26,7 @@ Deploy Eclipse Dirigible in Docker.
     === "Run"
 
         ```
-        docker run --name dirigible \
-        --rm -p 8080:8080 -p 8081:8081 \
-        dirigiblelabs/dirigible:latest
+        docker run --name dirigible --rm -p 8080:8080 -p 8081:8081 dirigiblelabs/dirigible:latest
         ```
 
     === "with Mounted Volume"


### PR DESCRIPTION
The docker command on windows needs to be on one line to be able to be executed in cmd.