### PR TITLE
Update help portal to match current dirigible implementation

### DIFF
--- a/docs-help/docs/community.md
+++ b/docs-help/docs/community.md
@@ -9,7 +9,7 @@ Welcome to the community page for contributors! Here you will find resources to 
 
 ## Contributor Guide
 
-Eclipse Dirigible is an open source project, which means that you can propose contributions by sending pull requests through [GitHub](https://github.com/eclipse/dirigible).
+Eclipse Dirigible is an open source project, which means that you can propose contributions by sending pull requests through [GitHub](https://github.com/eclipse-dirigible/dirigible).
 
 Before you get started, here are some prerequisites that you need to complete:
 
@@ -17,7 +17,7 @@ Before you get started, here are some prerequisites that you need to complete:
 
 Please read the [Eclipse Foundation policy on accepting contributions via Git](https://wiki.eclipse.org/Development_Resources/Contributing_via_Git).
 
-Please read the [Code of Conduct](https://github.com/eclipse/dirigible/blob/master/CODE_OF_CONDUCT.md).
+Please read the [Code of Conduct](https://github.com/eclipse-dirigible/dirigible/blob/master/CODE_OF_CONDUCT.md).
 
 Your contribution cannot be accepted unless you have an [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php) in place.
 
@@ -28,7 +28,7 @@ Here is the checklist for contributions to be acceptable:
 3. [Log into the projects portal](https://projects.eclipse.org/), look for ["Eclipse Contributor Agreement"](https://www.eclipse.org/legal/ECA.php), and agree to the terms.
 4. Ensure that you sign-off your Git commits with the same email address as your Eclipse Foundation profile. 
 
-For  more information see the [Contributor Guide](https://github.com/eclipse/dirigible/blob/master/CONTRIBUTING.md).
+For  more information see the [Contributor Guide](https://github.com/eclipse-dirigible/dirigible/blob/master/CONTRIBUTING.md).
 
 ### Style Guide
 

--- a/docs-help/docs/developer-resources/java-remote-debugging.md
+++ b/docs-help/docs/developer-resources/java-remote-debugging.md
@@ -11,31 +11,29 @@ Debugging
 
 To connect for remote java debugging of Eclipse Dirigible, follow the next steps:
 
-1. Start the Tomcat server in [JPDA (debug)](https://cwiki.apache.org/confluence/display/TOMCAT/Developing#Developing-Debugging) mode:
+1. Start the Dirigible executable JAR with the JDWP agent enabled. The runtime ships as a self-contained Spring Boot fat JAR (`dirigible-application-*-executable.jar` under `build/application/target/`), so the standard `-agentlib:jdwp=...` JVM flag is all that is needed:
 
-    !!! example "Run Tomcat in JPDA mode"
+    !!! example "Start Dirigible with the JDWP agent"
 
-        === "on macOS"
-
-            ```
-            ./catalina.sh jpda run
-            ```
-
-        === "on Linux"
+        === "on macOS / Linux"
 
             ```
-            ./catalina.sh jpda run
+            java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000 \
+              -jar build/application/target/dirigible-application-*-executable.jar
             ```
 
-        === "on Windows"
+        === "on Windows (PowerShell)"
 
             ```
-            catalina.bat jpda run
+            java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000 `
+              -jar build/application/target/$((Get-ChildItem dirigible-application-*-executable.jar -recurse -File | Sort-Object LastWriteTime | Select -Last 1).BaseName).jar
             ```
 
         === "Docker Image"
 
             Run the docker image **with Java Debugging Options** as described [here](/help/setup/docker/).
+
+    The JVM will listen for debugger attaches on **port 8000** (configurable via the `address=` part of the agent string). Use `suspend=y` instead of `suspend=n` if you need the JVM to wait for the debugger before continuing startup.
 
 === "Eclipse IDE"
 

--- a/docs-help/docs/development/artifacts/data-files.md
+++ b/docs-help/docs/development/artifacts/data-files.md
@@ -28,9 +28,9 @@ To make it more flexible it is introduced semantic files as follows:
 
     Data Structures and Data Files samples could be found here:
 
-    - [Database Table _`(*.table)`_](https://github.com/eclipse/dirigible/blob/master/modules/database/database-data-structures/src/test/resources/orders.table).
-    - [Database View _`(*.view)`_](https://github.com/eclipse/dirigible/blob/master/modules/database/database-data-structures/src/test/resources/orders.view).
-    - [Data Replace _`(*.replace)`_](https://github.com/eclipse/dirigible/blob/master/modules/database/database-data-structures/src/test/resources/orders.replace).
-    - [Data Append _`(*.append)`_](https://github.com/eclipse/dirigible/blob/master/modules/database/database-data-structures/src/test/resources/orders.append).
-    - [Data Delete _`(*.delete)`_](https://github.com/eclipse/dirigible/blob/master/modules/database/database-data-structures/src/test/resources/orders.delete).
-    - [Data Update _`(*.update)`_](https://github.com/eclipse/dirigible/blob/master/modules/database/database-data-structures/src/test/resources/orders.update).
+    - [Database Table _`(*.table)`_](https://github.com/eclipse-dirigible/dirigible/blob/master/modules/database/database-data-structures/src/test/resources/orders.table).
+    - [Database View _`(*.view)`_](https://github.com/eclipse-dirigible/dirigible/blob/master/modules/database/database-data-structures/src/test/resources/orders.view).
+    - [Data Replace _`(*.replace)`_](https://github.com/eclipse-dirigible/dirigible/blob/master/modules/database/database-data-structures/src/test/resources/orders.replace).
+    - [Data Append _`(*.append)`_](https://github.com/eclipse-dirigible/dirigible/blob/master/modules/database/database-data-structures/src/test/resources/orders.append).
+    - [Data Delete _`(*.delete)`_](https://github.com/eclipse-dirigible/dirigible/blob/master/modules/database/database-data-structures/src/test/resources/orders.delete).
+    - [Data Update _`(*.update)`_](https://github.com/eclipse-dirigible/dirigible/blob/master/modules/database/database-data-structures/src/test/resources/orders.update).

--- a/docs-help/docs/development/artifacts/database-table.md
+++ b/docs-help/docs/development/artifacts/database-table.md
@@ -72,23 +72,23 @@ The activation of the table descriptor is the process of creating a database tab
 	
 ## Scripting Services
 
-* Support of JavaScript language by using [GraalVM JS](https://github.com/eclipse/dirigible/tree/master/modules/engines/engine-javascript-graalvm) as runtime execution engine (`*.js`).
+* Support of JavaScript language by using [GraalVM JS](https://github.com/eclipse-dirigible/dirigible/tree/master/modules/engines/engine-javascript-graalvm) as runtime execution engine (`*.js`).
 <!-- * Support of CommonJS based modularization of JavaScript services (`*.js`). -->
 * Support of strictly defined enterprise [ API](../../../api/) for JavaScript to be used by the business application developers.
 
 ## Web Content
 
-* Support of client-side [Web](https://github.com/eclipse/dirigible/tree/master/modules/engines/engine-web) related artifacts, such as HTML, CSS, JS, pictures, etc.
+* Support of client-side [Web](https://github.com/eclipse-dirigible/dirigible/tree/master/modules/engines/engine-web) related artifacts, such as HTML, CSS, JS, pictures, etc.
 	
 ## Wiki Content
 
-* Support of [Markdown](https://daringfireball.net/projects/markdown/syntax) format for [Wiki](https://github.com/eclipse/dirigible/tree/master/modules/engines/engine-wiki) pages.
+* Support of [Markdown](https://daringfireball.net/projects/markdown/syntax) format for [Wiki](https://github.com/eclipse-dirigible/dirigible/tree/master/modules/engines/engine-wiki) pages.
 	
 ## Integration Services
 
 * Support of listeners for messages from the built-in message bus (`*.listener`).
 * Support of scheduled jobs as triggers for backend services invocation (`*.job`).
-* Support of business processes defined in BPMN 2.0 and executed by the underlying [BPM](https://github.com/eclipse/dirigible/tree/master/modules/bpm/bpm-flowable) process engine (`*.bpmn`).
+* Support of business processes defined in BPMN 2.0 and executed by the underlying [BPM](https://github.com/eclipse-dirigible/dirigible/tree/master/modules/bpm/bpm-flowable) process engine (`*.bpmn`).
 * Support of shell commands execution (`*.command`).
 * Support of [OData 2.0](https://olingo.apache.org/) (`*.odata`).
 * Support of websockets (`*.websocket`).

--- a/docs-help/docs/development/artifacts/index.md
+++ b/docs-help/docs/development/artifacts/index.md
@@ -12,28 +12,28 @@ Artifacts Overview
 
 ### Database
 
-  - [*.table](https://github.com/eclipse/dirigible/tree/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/tables) - a JSON based database table descriptor file. Data structures synchroniser automatically reads all the available *.table files in the repository (including the classpath resources) and creates the underlying database tables into the default database. The definition supports also dependencies which gives the ability to the synchroniser to make a topological sorting before starting the creation of the database artefacts.
+  - [*.table](https://github.com/eclipse-dirigible/dirigible/tree/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/tables) - a JSON based database table descriptor file. Data structures synchroniser automatically reads all the available *.table files in the repository (including the classpath resources) and creates the underlying database tables into the default database. The definition supports also dependencies which gives the ability to the synchroniser to make a topological sorting before starting the creation of the database artefacts.
 
-  - [*.view](https://github.com/eclipse/dirigible/tree/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/views) - a JSON based database table descriptor file. The synchroniser reads and creates the database views as defined in the model.
+  - [*.view](https://github.com/eclipse-dirigible/dirigible/tree/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/views) - a JSON based database table descriptor file. The synchroniser reads and creates the database views as defined in the model.
 
-  - [*.csvim](https://github.com/eclipse/dirigible/tree/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/csvim) - a JSON based descriptor file containing, pointing to a CSV file to be imported to the configured database table.
+  - [*.csvim](https://github.com/eclipse-dirigible/dirigible/tree/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/csvim) - a JSON based descriptor file containing, pointing to a CSV file to be imported to the configured database table.
 
 ### Security
 
-  - [*.access](https://github.com/eclipse/dirigible/blob/master/components/engine/engine-security/src/test/resources/META-INF/dirigible/test/test.access) - security constraints file. It defines the access permissions for the given endpoints.
-  - [*.role](https://github.com/eclipse/dirigible/blob/master/components/engine/engine-security/src/test/resources/META-INF/dirigible/test/test.role) - roles definition file.
+  - [*.access](https://github.com/eclipse-dirigible/dirigible/blob/master/components/engine/engine-security/src/test/resources/META-INF/dirigible/test/test.access) - security constraints file. It defines the access permissions for the given endpoints.
+  - [*.role](https://github.com/eclipse-dirigible/dirigible/blob/master/components/engine/engine-security/src/test/resources/META-INF/dirigible/test/test.role) - roles definition file.
 
 
 ### Flows
 
-  - [*.listener](https://github.com/eclipse/dirigible/blob/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/listeners/test.listener) - listener definition describing the link between the message queue or topic and the corresponding handler.
-  - [*.job](https://github.com/eclipse/dirigible/blob/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/jobs/test.job) - job definition describing the period in which the scheduled handler will be executed.
+  - [*.listener](https://github.com/eclipse-dirigible/dirigible/blob/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/listeners/test.listener) - listener definition describing the link between the message queue or topic and the corresponding handler.
+  - [*.job](https://github.com/eclipse-dirigible/dirigible/blob/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/jobs/test.job) - job definition describing the period in which the scheduled handler will be executed.
 
 
 ### Scripting
 
-  - [*.js](https://github.com/eclipse/dirigible/blob/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/datastore/student.mjs) - a JavaScript file supposed to be executed either server-side by the supported engine (GraalJS) or at the client-side by the browser's built-in engine.
-  - [*.command](https://github.com/eclipse/dirigible/blob/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/command/uname.command) - a Shell Command service
+  - [*.js](https://github.com/eclipse-dirigible/dirigible/blob/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/datastore/student.mjs) - a JavaScript file supposed to be executed either server-side by the supported engine (GraalJS) or at the client-side by the browser's built-in engine.
+  - [*.command](https://github.com/eclipse-dirigible/dirigible/blob/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/command/uname.command) - a Shell Command service
   - [*.md](https://raw.githubusercontent.com/eclipse/dirigible/master/README.md) - a Markdown Wiki file.
 
     !!! note "ES6 and TypeScript"
@@ -42,8 +42,8 @@ Artifacts Overview
 
 ### Modeling
 
-  - [*.dsm](https://github.com/eclipse/dirigible/blob/master/components/engine/engine-odata/src/test/resources/cars/Cars.dsm) - an internal XML based format file containing a database schema model diagram.
-  - [*.schema](https://github.com/eclipse/dirigible/blob/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/schemas/test.schema) - a JSON descriptor for a database schema layout produced by the Database Schema Modeler 
+  - [*.dsm](https://github.com/eclipse-dirigible/dirigible/blob/master/components/engine/engine-odata/src/test/resources/cars/Cars.dsm) - an internal XML based format file containing a database schema model diagram.
+  - [*.schema](https://github.com/eclipse-dirigible/dirigible/blob/master/components/test-project/src/main/resources/META-INF/dirigible/test-project/schemas/test.schema) - a JSON descriptor for a database schema layout produced by the Database Schema Modeler 
   - [*.edm](https://github.com/dirigiblelabs/demo-eclipsecon2018-edm-bookshop-admin/blob/master/bookshop-admin/bookshop.edm) - an internal XML based format file containing an entity data model diagram.
   - [*.model](https://github.com/dirigiblelabs/demo-eclipsecon2018-edm-bookshop-admin/blob/master/bookshop-admin/bookshop.model) - a JSON descriptor for an entity data model produced by the Entity Data Modeler
   - [*.bpmn](https://github.com/dirigiblelabs/sample-bpm/blob/master/sample-bpm/time-entry-request.bpmn) - a BPMN 2.0 XML file containing a definition of a business process.

--- a/docs-help/docs/development/concepts/entity-service.md
+++ b/docs-help/docs/development/concepts/entity-service.md
@@ -84,11 +84,11 @@ Generic query methods are not generated because:
 Entity services are generated in JavaScript, hence they can be accessed right after generation and publishing on:
 
 
-`<protocol>://<host>:<port>/services/v4/js/<project>/<entity-service-path>`
+`<protocol>://<host>:<port>/services/js/<project>/<entity-service-path>`
 
 Here's an example:
 
-`https://example.com/services/v4/js/bookstore/books.js`
+`https://example.com/services/js/bookstore/books.js`
 
 Or just select them in the **Workspace** view and check the result in the **Preview** view.
 

--- a/docs-help/docs/development/concepts/rest.md
+++ b/docs-help/docs/development/concepts/rest.md
@@ -21,7 +21,7 @@ rs.service()
   .execute();
 ```
 
-Sending a `GET` request to `/services/v4/js/test/hello-api.js` to the server and hosting the `hello-api.js` piece of code above in `test/hello-api.js` will return response body:
+Sending a `GET` request to `/services/js/test/hello-api.js` to the server and hosting the `hello-api.js` piece of code above in `test/hello-api.js` will return response body:
 
 > `Hello there!`  
 
@@ -107,7 +107,7 @@ Resources are the top-level configuration objects that represent an [HTTP (serve
 
 ### Resource paths and path templates
 
-The `sPath` string parameter (mandatory) of the `resource()` method will serve as the resource URL. It is relative to the location where the JavaScript service is running (e.g. `/services/v4/my-application/api/my-service.js`). No path (`""`), request directly to the JavaScript service root (`""`) path.
+The `sPath` string parameter (mandatory) of the `resource()` method will serve as the resource URL. It is relative to the location where the JavaScript service is running (e.g. `/services/my-application/api/my-service.js`). No path (`""`), request directly to the JavaScript service root (`""`) path.
 The path can also be a URL template, i.e. parameterized.  
 For example consider the path template:  
 

--- a/docs-help/docs/development/index.md
+++ b/docs-help/docs/development/index.md
@@ -18,7 +18,7 @@ This guide explains how to setup an Eclipse Dirigible instance and how to use it
 ### Get the binary
 
 * In case you want to use a prebuild package, you can get the one built for your environment from the [downloads](http://download.dirigible.io/) section.
-* To build Eclipse Dirigible from sources by yourself, just follow the instructions in the [README](https://github.com/eclipse/dirigible/blob/master/README.md#build).
+* To build Eclipse Dirigible from sources by yourself, just follow the instructions in the [README](https://github.com/eclipse-dirigible/dirigible/blob/master/README.md#build).
 
 ### Choose the environment
 

--- a/docs-help/docs/overview/architecture.md
+++ b/docs-help/docs/overview/architecture.md
@@ -11,20 +11,21 @@ The components are separated between the design time (definition work, modeling,
 
 ![Dirigible Design Time and Runtime](../images/architecture_designtime_runtime.png)
 
-At design time, the programmers and designers use the Web-based integrated development environment [Web IDE](../../development/ide). This tooling is based on the most popular client side JavaScript framework - AngularJS, as well as Bootstrap for theme-ing and GoldenLayout for windows management.
+At design time, the programmers and designers use the Web-based integrated development environment [Web IDE](../../development/ide). The IDE front-end is built with TypeScript and HTML, using the [BlimpKit](https://github.com/blimpkit/blimpkit.github.io) component framework for UI elements and the [Monaco](https://github.com/microsoft/monaco-editor) editor for code editing.
 
 ![Dirigible Design Time and Runtime](../images/ide_workbench_perspective.png)
 
-The runtime components provide the cloud application after you create it. The underlying technology platform is a Java-Web-Profile-compliant application server (such as Tomcat). On top are the Eclipse Dirigible containers for service execution. Depending on the scripting language and purpose, they can be:
- 
-* GraalVM JS 
-* Mylyn
-* Lucene
-* Quartz 
-* ActiveMQ
-* Flowable
-* Mustache 
-* Chemistry 
+The runtime is delivered as a self-contained Spring Boot executable JAR (built with Java 21) that embeds all execution engines and the IDE web content. On top of the Spring Boot platform, Eclipse Dirigible ships dedicated engines for service execution. Depending on the scripting language and purpose, they include:
+
+* GraalVM JavaScript / TypeScript (via [Graalium](https://github.com/eclipse-dirigible/graalium))
+* Python
+* [Flowable](https://www.flowable.org/) (BPMN)
+* [Apache Camel](https://camel.apache.org/) (integration routes)
+* Quartz (scheduled jobs)
+* Mustache / Velocity (template engines)
+* Lucene (indexing)
+* Chemistry (CMIS / Content Management)
+* Mylyn WikiText (Markdown / wiki rendering)
 
 The runtime can be scaled independently from the design time and can be deployed without the design time at all (for productive landscapes).
 

--- a/docs-help/docs/overview/engines.md
+++ b/docs-help/docs/overview/engines.md
@@ -7,15 +7,22 @@ Engines
 
 ## Engines List
 
-- [Javascript GraalVM JS](https://github.com/eclipse/dirigible/tree/master/modules/engines/engine-javascript-graalvm) - a Javascript module based on the [GraalVM JS](https://www.graalvm.org/reference-manual/js/) engine.
-- [Web](https://github.com/eclipse/dirigible/tree/master/modules/engines/engine-web) - serving the static content via the underlying web container's capabilities e.g. [Apache Tomcat](http://tomcat.apache.org/).
-- [Wiki Markdown](https://github.com/eclipse/dirigible/tree/master/modules/engines/engine-wiki) - a Wiki engine supporting [Markdown](https://daringfireball.net/projects/markdown/syntax) markup language and uses the [Mylyn](https://wiki.eclipse.org/Mylyn/WikiText) underlying framework.
-- [BPM](https://github.com/eclipse/dirigible/tree/master/modules/bpm/bpm-flowable) - a [BPMN](http://www.omg.org/bpmn/) specification supporting engine [Flowable](https://www.flowable.org/).
-- [OData](https://olingo.apache.org/) - expose OData services from database tables/views.
-- Command - execute shell commands and bash scripts.
+The execution engines live under [`components/engine/`](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine) in the source repository. Each engine is auto-discovered by the Spring Boot runtime when its module is on the classpath.
 
-## Deprecated
-
-- [Javascript Rhino](https://github.com/eclipse/dirigible/tree/master/modules/engines/engine-javascript-rhino) - a Javascript module based on the [Mozilla Rhino](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Rhino) engine.
-- [Javascript Nashorn](https://github.com/eclipse/dirigible/tree/master/modules/engines/engine-javascript-nashorn) - a Javascript module based on the built-in Java [Nashorn](http://www.oracle.com/technetwork/articles/java/jf14-nashorn-2126515.html) engine.
-- [Javascript V8](https://github.com/eclipse/dirigible/tree/master/modules/engines/engine-javascript-v8) - a Javascript module based on the [Chrome V8](https://developers.google.com/v8/) engine.
+- [JavaScript](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-javascript) - server-side JavaScript executed on top of [GraalVM](https://www.graalvm.org/reference-manual/js/) via the embedded [Graalium](https://github.com/eclipse-dirigible/graalium) runtime.
+- [TypeScript](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-typescript) - TypeScript support, transpiled with `tsc`/`esbuild` and executed through the JavaScript engine.
+- [Python](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-python) - Python support powered by GraalPy.
+- [Web](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-web) - serves static content (HTML, CSS, JS, images) directly out of the repository.
+- [Wiki Markdown](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-wiki) - renders [Markdown](https://daringfireball.net/projects/markdown/syntax) using the [Mylyn WikiText](https://wiki.eclipse.org/Mylyn/WikiText) framework.
+- [BPM (Flowable)](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-bpm-flowable) - a [BPMN 2.0](http://www.omg.org/bpmn/) execution engine based on [Flowable](https://www.flowable.org/).
+- [Camel](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-camel) - [Apache Camel](https://camel.apache.org/) integration routes.
+- [Jobs](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-jobs) - scheduled jobs backed by [Quartz](https://www.quartz-scheduler.org/).
+- [Listeners](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-listeners) - JMS / message-queue listeners.
+- [OData](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-odata) - expose [OData v2](https://olingo.apache.org/) services from database tables/views (served at `/odata/v2`).
+- [OpenAPI](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-openapi) - aggregates OpenAPI/Swagger definitions of the running services.
+- [WebSockets](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-websockets) - server-side WebSocket endpoints.
+- [CMS](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-cms) - Content Management with pluggable backends ([Internal](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-cms-internal), [S3](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-cms-s3), [SharePoint](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-cms-sharepoint)).
+- [Command](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-command) - execute shell commands and scripts.
+- Template engines - [JavaScript](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-template-javascript), [Mustache](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-template-mustache), and [Velocity](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-template-velocity).
+- [SFTP](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-sftp) / [FTP](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-ftp) - file-transfer endpoints.
+- [OpenTelemetry](https://github.com/eclipse-dirigible/dirigible/tree/master/components/engine/engine-open-telemetry) - traces, metrics, and logs exporter.

--- a/docs-help/docs/overview/faq.md
+++ b/docs-help/docs/overview/faq.md
@@ -2,7 +2,7 @@
 title: FAQ
 ---
 
-*If you have a question that is not covered here, but it should be, please let us [know](https://github.com/eclipse/dirigible/issues).* 
+*If you have a question that is not covered here, but it should be, please let us [know](https://github.com/eclipse-dirigible/dirigible/issues).* 
 
 
 ## Concepts
@@ -131,11 +131,11 @@ title: FAQ
 
 ??? question "How to integrate my Java framework?"
 
-    It is even simpler - add it during the packaging phase as a regular Maven module to be packaged in the WAR or the executable JAR files.
+    It is even simpler - add it during the packaging phase as a regular Maven module to be packaged in the Spring Boot executable JAR.
 
 ??? question "How to register my Enterprise JavaScript API?"
 
-    Once you make the your core framework available as a Maven module packaged into your WAR file, you can implement your own [Enterprise JavaScript API](../../../api/) facade.
+    Once you make the your core framework available as a Maven module packaged into the executable JAR, you can implement your own [Enterprise JavaScript API](../../../api/) facade.
 
 ??? question "How to integrate my non-Java framework?"
 

--- a/docs-help/docs/overview/features.md
+++ b/docs-help/docs/overview/features.md
@@ -19,23 +19,23 @@ Features
 	
 ## Scripting Services
 
-* Support of JavaScript language by using [GraalVM JS](https://github.com/eclipse/dirigible/tree/master/modules/engines/engine-javascript-graalvm) as runtime execution engine (`*.js`).
+* Support of JavaScript language by using [GraalVM JS](https://github.com/eclipse-dirigible/dirigible/tree/master/modules/engines/engine-javascript-graalvm) as runtime execution engine (`*.js`).
 * Support for Typescript services (`*.ts`).
 * Support of strictly defined enterprise [ API](../../../api/) for JavaScript to be used by the business application developers.
 
 ## Web Content
 
-* Support of client-side [Web](https://github.com/eclipse/dirigible/tree/master/modules/engines/engine-web) related artifacts, such as HTML, CSS, JS, pictures, etc.
+* Support of client-side [Web](https://github.com/eclipse-dirigible/dirigible/tree/master/modules/engines/engine-web) related artifacts, such as HTML, CSS, JS, pictures, etc.
 	
 ## Wiki Content
 
-* Support of [Markdown](https://daringfireball.net/projects/markdown/syntax) format for [Wiki](https://github.com/eclipse/dirigible/tree/master/modules/engines/engine-wiki) pages.
+* Support of [Markdown](https://daringfireball.net/projects/markdown/syntax) format for [Wiki](https://github.com/eclipse-dirigible/dirigible/tree/master/modules/engines/engine-wiki) pages.
 	
 ## Integration Services
 
 * Support of listeners for messages from the built-in message bus (`*.listener`).
 * Support of scheduled jobs as triggers for backend services invocation (`*.job`).
-* Support of business processes defined in BPMN 2.0 and executed by the underlying [BPM](https://github.com/eclipse/dirigible/tree/master/modules/bpm/bpm-flowable) process engine (`*.bpmn`).
+* Support of business processes defined in BPMN 2.0 and executed by the underlying [BPM](https://github.com/eclipse-dirigible/dirigible/tree/master/modules/bpm/bpm-flowable) process engine (`*.bpmn`).
 * Support of shell commands execution (`*.command`).
 * Support of [OData 2.0](https://olingo.apache.org/) (`*.odata`).
 * Support of websockets (`*.websocket`).

--- a/docs-help/docs/setup/cloud-foundry.md
+++ b/docs-help/docs/setup/cloud-foundry.md
@@ -107,7 +107,7 @@ Deploy Eclipse Dirigible in SAP BTP[^1], Cloud Foundry environment.
         !!! tip "Eclipse Dirigible versions"
             Instead of using the `latest` tag (version), for production and development use cases it is recomended to use a stable release version:
             
-            - All released versions can be found [here](https://github.com/eclipse/dirigible/releases/).
+            - All released versions can be found [here](https://github.com/eclipse-dirigible/dirigible/releases/).
             - All Eclipse Dirigible Docker images and tags (versions) can be found [here](https://hub.docker.com/u/dirigiblelabs).
 
         - Bind the XSUAA service instance to the Eclipse Dirigible deployment:

--- a/docs-help/docs/setup/docker.md
+++ b/docs-help/docs/setup/docker.md
@@ -68,7 +68,7 @@ Deploy Eclipse Dirigible in Docker.
     !!! tip "Eclipse Dirigible versions"
         Instead of using the `latest` tag (version), for production and development use cases it is recomended to use a stable release version:
         
-        - All released versions can be found [here](https://github.com/eclipse/dirigible/releases/).
+        - All released versions can be found [here](https://github.com/eclipse-dirigible/dirigible/releases/).
         - All Eclipse Dirigible Docker images and tags (versions) can be found [here](https://hub.docker.com/u/dirigiblelabs).
 
 

--- a/docs-help/docs/setup/kubernetes/azure-kubernetes-service.md
+++ b/docs-help/docs/setup/kubernetes/azure-kubernetes-service.md
@@ -191,7 +191,7 @@ Deploy Eclipse Dirigible in Azure Kubernetes Services(AKS) environment.
     !!! tip "Eclipse Dirigible versions"
         Instead of using the `latest` tag (version), for production and development use cases it is recomended to use a stable release version:
         
-        - All released versions can be found [here](https://github.com/eclipse/dirigible/releases/).
+        - All released versions can be found [here](https://github.com/eclipse-dirigible/dirigible/releases/).
         - All Eclipse Dirigible Docker images and tags (versions) can be found [here](https://hub.docker.com/u/dirigiblelabs).
 
 1. Create service configuration file: `service.yaml`

--- a/docs-help/docs/setup/kubernetes/google-kubernetes-engine.md
+++ b/docs-help/docs/setup/kubernetes/google-kubernetes-engine.md
@@ -194,7 +194,7 @@ Deploy Eclipse Dirigible in Google Kubernetes Engine (GKE) environment.
     !!! tip "Eclipse Dirigible versions"
         Instead of using the `latest` tag (version), for production and development use cases it is recomended to use a stable release version:
         
-        - All released versions can be found [here](https://github.com/eclipse/dirigible/releases/).
+        - All released versions can be found [here](https://github.com/eclipse-dirigible/dirigible/releases/).
         - All Eclipse Dirigible Docker images and tags (versions) can be found [here](https://hub.docker.com/u/dirigiblelabs).
 
 1. Create service configuration file: `service.yaml`

--- a/docs-help/docs/setup/kubernetes/helm.md
+++ b/docs-help/docs/setup/kubernetes/helm.md
@@ -258,7 +258,7 @@ The following table lists all the configurable parameters expose by the Dirigibl
 |             Name             |          Description            |            Default                 |
 |------------------------------|---------------------------------|------------------------------------|
 | `dirigible.image`            | Custom Dirigible image          | `""`                               |
-| `image.repository`           | Dirigible image repo            | `dirigiblelabs/dirigible-all`      |
+| `image.repository`           | Dirigible image repo            | `dirigiblelabs/dirigible`          |
 | `image.repositoryKyma`       | Dirigible Kyma image repo       | `dirigiblelabs/dirigible-sap-kyma` |
 | `image.repositoryKeycloak`   | Dirigible Keycloak image repo   | `dirigiblelabs/dirigible-keycloak` |
 | `image.pullPolicy`           | Image pull policy               | `IfNotPresent`                     |
@@ -279,11 +279,11 @@ The following table lists all the configurable parameters expose by the Dirigibl
 |             Name             |          Description            |            Default                 |
 |------------------------------|---------------------------------|------------------------------------|
 | `volume.enabled`             | Volume to be mounted            | `true`                             |
-| `volume.storage`             | Volume storage size             | `1Gi`                              |
+| `volume.storage`             | Volume storage size             | `2Gi`                              |
 | `database.enabled`           | Database to be deployed         | `false`                            |
-| `database.image`             | Database image                  | `postgres:13`                      |
+| `database.image`             | Database image                  | `postgres:14`                      |
 | `database.driver`            | Database JDBC driver            | `org.postgresql.Driver`            |
-| `database.storage`           | Database storage size           | `1Gi`                              |
+| `database.storage`           | Database storage size           | `2Gi`                              |
 | `database.username`          | Database username               | `dirigible`                        |
 | `database.password`          | Database password               | `dirigible`                        |
 | `ingress.enabled`            | Ingress to be created           | `false`                            |
@@ -323,7 +323,7 @@ The following table lists all the configurable parameters expose by the Dirigibl
 | `keycloak.enabled`           | Keycloak environment to be used | `false`                            |
 | `keycloak.install`           | Keycloak to be installed        | `false`                            |
 | `keycloak.name`              | Keycloak deployment name        | `keycloak`                         |
-| `keycloak.image`             | Keycloak image                  | `jboss/keycloak:12.0.4`            |
+| `keycloak.image`             | Keycloak image                  | `jboss/keycloak:16.1.1`            |
 | `keycloak.username`          | Keycloak username               | `admin`                            |
 | `keycloak.password`          | Keycloak password               | `admin`                            |
 | `keycloak.replicaCount`      | Keycloak number of replicas     | `1`                                |
@@ -332,7 +332,7 @@ The following table lists all the configurable parameters expose by the Dirigibl
 | `keycloak.database.enabled`  | Keycloak database to be used    | `false`                            |
 | `keycloak.database.enabled`  | Keycloak database to be used    | `true`                             |
 | `keycloak.database.image`    | Keycloak database image         | `postgres:13`                      |
-| `keycloak.database.storage`  | Keycloak database storage size  | `1Gi`                              |
+| `keycloak.database.storage`  | Keycloak database storage size  | `2Gi`                              |
 | `keycloak.database.username` | Keycloak database username      | `keycloak`                         |
 | `keycloak.database.password` | Keycloak database password      | `keycloak`                         |
 
@@ -355,4 +355,4 @@ helm install dirigible dirigible/dirigible --values values.yaml
 ```
 
 !!! tip
-	You can use the default [values.yaml](https://github.com/eclipse/dirigible/blob/master/releng/helm-charts/dirigible/values.yaml).
+	You can use the default [values.yaml](https://github.com/eclipse-dirigible/dirigible/blob/master/releng/helm-charts/dirigible/values.yaml).

--- a/docs-help/docs/setup/kubernetes/index.md
+++ b/docs-help/docs/setup/kubernetes/index.md
@@ -144,7 +144,7 @@ You can deploy [Eclipse Dirigible](https://hub.docker.com/r/dirigiblelabs) Docke
     !!! tip "Eclipse Dirigible versions"
         Instead of using the `latest` tag (version), for production and development use cases it is recomended to use a stable release version:
         
-        - All released versions can be found [here](https://github.com/eclipse/dirigible/releases/).
+        - All released versions can be found [here](https://github.com/eclipse-dirigible/dirigible/releases/).
         - All Eclipse Dirigible Docker images and tags (versions) can be found [here](https://hub.docker.com/u/dirigiblelabs).
 
 1. Create service configuration file: `service.yaml`
@@ -286,7 +286,7 @@ To update the Eclipse Dirigible version either use the **kubectl** or update the
 
     Update the `<dirigible-version>` placeholder with a stable release version:
 
-    - You can find all released versions [here](https://github.com/eclipse/dirigible/releases/).
+    - You can find all released versions [here](https://github.com/eclipse-dirigible/dirigible/releases/).
     - You can find all Eclipse Dirigible Docker images and tags (versions) [here](https://hub.docker.com/u/dirigiblelabs).
 
 ### Scaling

--- a/docs-help/docs/setup/kubernetes/red-hat-openshift.md
+++ b/docs-help/docs/setup/kubernetes/red-hat-openshift.md
@@ -201,7 +201,7 @@ Deploy Eclipse Dirigible in Red Hat OpenShift environment.
     !!! tip "Eclipse Dirigible versions"
         Instead of using the `latest` tag (version), for production and development use cases it is recomended to use a stable release version:
         
-        - All released versions can be found [here](https://github.com/eclipse/dirigible/releases/).
+        - All released versions can be found [here](https://github.com/eclipse-dirigible/dirigible/releases/).
         - All Eclipse Dirigible Docker images and tags (versions) can be found [here](https://hub.docker.com/u/dirigiblelabs).
 
 1. Create service configuration file: `service.yaml`

--- a/docs-help/docs/setup/kubernetes/sap-btp-kyma.md
+++ b/docs-help/docs/setup/kubernetes/sap-btp-kyma.md
@@ -126,7 +126,7 @@ Deploy Eclipse Dirigible in SAP BTP[^1], Kyma environment.
     !!! tip "Eclipse Dirigible versions"
         Instead of using the `latest` tag (version), for production and development use cases it is recomended to use stable release version:
 
-        - All released versions can be found [here](https://github.com/eclipse/dirigible/releases/).
+        - All released versions can be found [here](https://github.com/eclipse-dirigible/dirigible/releases/).
         - All Eclipse Dirigible Docker images and tags (versions) can be found [here](https://hub.docker.com/u/dirigiblelabs).
 
 1. Create service configuration file: `service.yaml`

--- a/docs-help/docs/setup/setup-environment-variables.md
+++ b/docs-help/docs/setup/setup-environment-variables.md
@@ -29,14 +29,14 @@ Based on the layer, they are defined, configuration variables have the following
     Third precedence:
     
     - Rebuild and re-deployment is required.
-    - "Default" deployment _(`ROOT.war`)_ configuration variables are taken from `dirigible.properties` properties file _(sample could be found [here](https://github.com/eclipse/dirigible/blob/master/releng/server-all/src/main/resources/dirigible.properties))_.
+    - "Default" deployment _(`ROOT.war`)_ configuration variables are taken from `dirigible.properties` properties file _(sample could be found [here](https://github.com/eclipse-dirigible/dirigible/blob/master/releng/server-all/src/main/resources/dirigible.properties))_.
 
 === "Module"
 
     Lowest precedence:
     
     - Rebuild and re-deployment is required.
-    - "Default" module _(e.g. `dirigible-database-custom.jar`, `dirigible-database-h2.jar`)_ configuration variables are taken from `dirigible-xxx.properties` properties files _(sample could be found [here](https://github.com/eclipse/dirigible/blob/master/modules/database/database-h2/src/main/resources/dirigible-database-h2.properties) and [here](https://github.com/eclipse/dirigible/blob/master/modules/database/database-custom/src/main/resources/dirigible-database-custom.properties))_
+    - "Default" module _(e.g. `dirigible-database-custom.jar`, `dirigible-database-h2.jar`)_ configuration variables are taken from `dirigible-xxx.properties` properties files _(sample could be found [here](https://github.com/eclipse-dirigible/dirigible/blob/master/modules/database/database-h2/src/main/resources/dirigible-database-h2.properties) and [here](https://github.com/eclipse-dirigible/dirigible/blob/master/modules/database/database-custom/src/main/resources/dirigible-database-custom.properties))_
 
 !!! Note
 	The precedence order means that, if the there is an **Environment** variable with name `DIRIGIBLE_TEST` and **Runtime** variable with the same name, the **Runtime** variable will have high prority and will be applied.

--- a/docs-help/docs/setup/setup-environment-variables.md
+++ b/docs-help/docs/setup/setup-environment-variables.md
@@ -72,27 +72,20 @@ Parameter     | Description | Default*
 **DIRIGIBLE_BASIC_USERNAME**   | Base64 encoded property, which will be used as user name for basic authentication | _`admin`_
 **DIRIGIBLE_BASIC_PASSWORD**   | Base64 encoded property, which will be used as password for basic authentication | _`admin`_
 
-### OAuth
+### OAuth (GitHub)
+
+OAuth login is provided via Spring Security and activated by enabling the `github` Spring profile (e.g. `SPRING_PROFILES_ACTIVE=github`). When the profile is active, configuration is read from `application-github.properties` using the following variables:
 
 Parameter     | Description | Default*
 ------------ | ----------- | --------
-**DIRIGIBLE_OAUTH_ENABLED** | Whether the OAuth authentication is enabled | _`false`_
-**DIRIGIBLE_OAUTH_AUTHORIZE_URL** | The OAuth authorization URL _(e.g. `https://my-oauth-server/oauth/authorize`)_ | _`-`_
-**DIRIGIBLE_OAUTH_TOKEN_URL** | The OAuth token URL _(e.g. `https://my-oauth-server/oauth/token`)_ | _`-`_
-**DIRIGIBLE_OAUTH_TOKEN_REQUEST_METHOD** | The OAuth token request method _(`GET` or `POST`)_ | _`GET`_
-**DIRIGIBLE_OAUTH_CLIENT_ID** | The OAuth `clientid` _(e.g. `sb-xxx-yyy`)_ | _`-`_
-**DIRIGIBLE_OAUTH_CLIENT_SECRET** | The OAuth `clientsecret` _(e.g. `PID/cpkD8aZzbGaa6+muYYOOMWPDeM1ug/sQ5ZF...`)_ | _`-`_
-**DIRIGIBLE_OAUTH_APPLICATION_HOST** | The application host _(e.g. `https://my-application-host`)_ | _`-`_
-**DIRIGIBLE_OAUTH_ISSUER** | The OAuth `issuer` _(e.g. `http://xxx.localhost:8080/uaa/oauth/token`)_ | _`-`_
-**DIRIGIBLE_OAUTH_VERIFICATION_KEY** | The OAuth `verificationkey` _(e.g. `-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhki...`)_ | _`-`_
-**DIRIGIBLE_OAUTH_VERIFICATION_KEY_EXPONENT** | The OAuth verificationkey exponent _(e.g. `AQAB`)_ | _`-`_
-**DIRIGIBLE_OAUTH_CHECK_ISSUER_ENABLED** | Sets whether the JWT verifier should check the token `issuer` | _`true`_
-**DIRIGIBLE_OAUTH_CHECK_AUDIENCE_ENABLED** | Sets whether the JWT verifier should check the token `aud` | _`true`_
-**DIRIGIBLE_OAUTH_APPLICATION_NAME** | The application name _(e.g. `dirigible-xxx`)_ | _`-`_
+**DIRIGIBLE_GITHUB_CLIENT_ID** | The OAuth `clientId` registered for the GitHub OAuth App | _`-`_
+**DIRIGIBLE_GITHUB_CLIENT_SECRET** | The OAuth `clientSecret` registered for the GitHub OAuth App | _`-`_
+**DIRIGIBLE_GITHUB_SCOPE** | The OAuth scopes requested from GitHub | _`read:user,user:email`_
+**DIRIGIBLE_HOST** | The application's public host used to build the OAuth redirect URI _(e.g. `https://my-application-host`)_ | _`-`_
 
 !!! Note "Redirect/Callback URL"
 
-    Configure the Redirect/Callback URL in the OAuth client to: `<DIRIGIBLE_OAUTH_APPLICATION_HOST>/services/v4/oauth/callback`
+    Configure the Authorization callback URL in the GitHub OAuth App to: `<DIRIGIBLE_HOST>/login/oauth2/code/github`
 
 ### Keycloak
 
@@ -316,7 +309,7 @@ Parameter     | Description | Default*
 
 Parameter     | Description | Default*
 ------------ | ----------- | --------
-**DIRIGIBLE_HOME_URL**   | The home URL where the user to be redirected on access | _`/services/v4/web/ide/index.html`_
+**DIRIGIBLE_HOME_URL**   | The home URL where the user to be redirected on access | _`services/web/shell-ide/`_
 
 ### Vert.x
 

--- a/docs-help/docs/tutorials/customizations/custom-stack/project-structure.md
+++ b/docs-help/docs/tutorials/customizations/custom-stack/project-structure.md
@@ -366,7 +366,7 @@ It contains the creation of several Maven `pom.xml` files, static content resour
 
     !!! tip "Eclipse Dirigible version"
 
-    	The tutorial is using Eclipse Dirigible version `10.2.7` as highlighted on line **229**. To check for a more recent and stable version go to [Eclipse Dirigible Releases](https://github.com/eclipse/dirigible/releases/).
+    	The tutorial is using Eclipse Dirigible version `10.2.7` as highlighted on line **229**. To check for a more recent and stable version go to [Eclipse Dirigible Releases](https://github.com/eclipse-dirigible/dirigible/releases/).
 
 === "application/pom.xml"
 

--- a/docs-help/docs/tutorials/customizations/ide/create-view.md
+++ b/docs-help/docs/tutorials/customizations/ide/create-view.md
@@ -109,17 +109,17 @@ All views in Eclipse Dirigible are loaded via the `ide-view` extension point. Li
                     <theme></theme>
             
                     <!-- Dirigible styles -->
-                    <link type="text/css" rel="stylesheet" href="/services/v4/web/resources/styles/core.css" />
-                    <link type="text/css" rel="stylesheet" href="/services/v4/web/resources/styles/widgets.css" />
+                    <link type="text/css" rel="stylesheet" href="/services/web/resources/styles/core.css" />
+                    <link type="text/css" rel="stylesheet" href="/services/web/resources/styles/widgets.css" />
             
                     <!-- MessageHub -->
-                    <script type="text/javascript" src="/services/v4/web/ide-core/core/message-hub.js"></script>
-                    <script type="text/javascript" src="/services/v4/web/ide-core/core/ide-message-hub.js"></script>
+                    <script type="text/javascript" src="/services/web/ide-core/core/message-hub.js"></script>
+                    <script type="text/javascript" src="/services/web/ide-core/core/ide-message-hub.js"></script>
             
                     <!-- IDE Core UI -->
-                    <script type="text/javascript" src="/services/v4/web/ide-core/ui/theming.js"></script>
-                    <script type="text/javascript" src="/services/v4/web/ide-core/ui/widgets.js"></script>
-                    <script type="text/javascript" src="/services/v4/web/ide-core/ui/view.js"></script>
+                    <script type="text/javascript" src="/services/web/ide-core/ui/theming.js"></script>
+                    <script type="text/javascript" src="/services/web/ide-core/ui/widgets.js"></script>
+                    <script type="text/javascript" src="/services/web/ide-core/ui/view.js"></script>
             
                     <!-- Project-specific stuff -->
                     <script type="text/javascript" src="controller.js"></script>

--- a/docs-help/docs/tutorials/modeling/bpmn-process.md
+++ b/docs-help/docs/tutorials/modeling/bpmn-process.md
@@ -149,7 +149,7 @@ JavaScript handlers should be provided for the `Service Task` steps in the `Busi
 
     	let urlEncodedData = base64.encode(JSON.stringify(data));
 
-    	let url = `http://localhost:8080/services/v4/web/sample-bpm/process/?data=${urlEncodedData}`;
+    	let url = `http://localhost:8080/services/web/sample-bpm/process/?data=${urlEncodedData}`;
 
     	console.log(`Approve Request URL: ${url}`);
 
@@ -571,7 +571,7 @@ The submit form would call the server-side javascript api that was created in th
     			};
 
     			$scope.submit = function () {
-    				$http.post("/services/v4/js/sample-bpm/api/process.js", JSON.stringify($scope.entity)).then(function (response) {
+    				$http.post("/services/js/sample-bpm/api/process.js", JSON.stringify($scope.entity)).then(function (response) {
     					if (response.status != 202) {
     						alert(`Unable to submit Time Entry Request: '${response.message}'`);
     						$scope.resetForm();
@@ -718,7 +718,7 @@ The process form would call the server-side javascript api that was created befo
     			};
 
     			$scope.approve = function () {
-    				$http.post("/services/v4/js/sample-bpm/api/process.js/continue/" + $scope.executionId, JSON.stringify(
+    				$http.post("/services/js/sample-bpm/api/process.js/continue/" + $scope.executionId, JSON.stringify(
     					{
     						user: $scope.user,
     						approved: true
@@ -734,7 +734,7 @@ The process form would call the server-side javascript api that was created befo
     			};
 
     			$scope.reject = function () {
-    				$http.post("/services/v4/js/sample-bpm/api/process.js/continue/" + $scope.executionId, JSON.stringify(
+    				$http.post("/services/js/sample-bpm/api/process.js/continue/" + $scope.executionId, JSON.stringify(
     					{
     						user: $scope.user,
     						approved: false
@@ -856,7 +856,7 @@ APP_SAMPLE_BPM_TO_EMAIL=<RECEIVER_EMAIL>
 
 [Using custom approval form]
 
-1. Navigate to [http://localhost:8080/services/v4/web/sample-bpm/submit/](http://localhost:8080/services/v4/web/sample-bpm/submit/) to open the **Submit form**.
+1. Navigate to [http://localhost:8080/services/web/sample-bpm/submit/](http://localhost:8080/services/web/sample-bpm/submit/) to open the **Submit form**.
 2. Enter the required data and press the **Submit** button.
 3. Navigate to the Processes Workspace
 4. Select your active process instance in the Process Instances view
@@ -872,13 +872,13 @@ APP_SAMPLE_BPM_TO_EMAIL=<RECEIVER_EMAIL>
 
 [Using approval url from the console]
 
-1. Navigate to [http://localhost:8080/services/v4/web/sample-bpm/submit/](http://localhost:8080/services/v4/web/sample-bpm/submit/) to open the **Submit form**.
+1. Navigate to [http://localhost:8080/services/web/sample-bpm/submit/](http://localhost:8080/services/web/sample-bpm/submit/) to open the **Submit form**.
 1. Enter the required data and press the **Submit** button.
 1. If email configuration was provided an email notification will be send to the email address set by the `APP_SAMPLE_BPM_TO_EMAIL=<RECEIVER_EMAIL>` environment variable.
 1. If email configuration wasn't provided then in the `Console` view the following message can be found:
 
    ```
-   Approve Request URL: http://localhost:8080/services/v4/web/sample-bpm/process/?data=eyJleGVjdXRpb25JZCI6IjE4Ni...
+   Approve Request URL: http://localhost:8080/services/web/sample-bpm/process/?data=eyJleGVjdXRpb25JZCI6IjE4Ni...
    ```
 
 1. Open the URL from the `Console` view or open it from the email notification.


### PR DESCRIPTION
## Summary

Audit pass against the [eclipse-dirigible/dirigible](https://github.com/eclipse-dirigible/dirigible) source. The portal had drifted in several places relative to the running implementation; this PR closes the verified gaps. **No content was changed where the docs were merely vague — only items I could confirm against the code were touched.**

### Mechanical sweeps

1. **GitHub org rename** — every `github.com/eclipse/dirigible` link → `github.com/eclipse-dirigible/dirigible`. 18 files affected. The repository was relocated; the old URLs still redirect but the canonical owner is the new org.
2. **Legacy `/services/v4/` URL prefix** — stripped to `/services/` in `development/concepts/rest.md`, `development/concepts/entity-service.md`, `tutorials/customizations/ide/create-view.md`, and `tutorials/modeling/bpmn-process.md`. The current servlet mapping is `/services/...` (with `/public/...` as the unauthenticated counterpart) per `BaseEndpoint.PREFIX_ENDPOINT_SECURED` in `components/core/core-base`.

### Setup / Environment Variables

3. **`OAuth` section rewritten as `OAuth (GitHub)`** — the legacy `DIRIGIBLE_OAUTH_*` block described a removed JWT/OAuth setup. The actual flow is now Spring Security's GitHub OAuth, activated by the `github` Spring profile and configured via `DIRIGIBLE_GITHUB_CLIENT_ID`, `DIRIGIBLE_GITHUB_CLIENT_SECRET`, `DIRIGIBLE_GITHUB_SCOPE` (default `read:user,user:email`), and `DIRIGIBLE_HOST`. Callback URL: `<DIRIGIBLE_HOST>/login/oauth2/code/github`. Source: `build/application/src/main/resources/application-github.properties` + `components/security/security-oauth2/.../OAuth2SecurityConfiguration.java` (`@Profile("github")`).
4. **`DIRIGIBLE_HOME_URL` default** — corrected from `/services/v4/web/ide/index.html` to `services/web/shell-ide/` to match `DirigibleConfig.HOME_URL`.

### Overview pages

5. **`overview/architecture.md`** — replaced the AngularJS / Bootstrap / GoldenLayout description of the IDE with the current frontend stack (TypeScript, BlimpKit components, Monaco editor). Replaced the "Java-Web-Profile-compliant application server (such as Tomcat)" claim with the actual Spring Boot fat-jar runtime. Refreshed the engine list to match `components/engine/` (Graalium-based JavaScript/TypeScript, Python, Camel, Flowable, Quartz, Lucene, Chemistry, Mustache/Velocity templates, Mylyn WikiText).
6. **`overview/engines.md`** — engine repo paths fixed (`modules/engines/engine-javascript-graalvm` → `components/engine/engine-javascript`, `modules/bpm/bpm-flowable` → `components/engine/engine-bpm-flowable`, etc.). Removed the "Deprecated" section listing Rhino / Nashorn / V8 — those modules no longer exist in the repository. Added the engines that do exist but were not previously listed (TypeScript, Python, Camel, Jobs/Quartz, Listeners, OpenAPI, WebSockets, CMS, SFTP/FTP, OpenTelemetry, template engines).
7. **`overview/faq.md`** — two answers referenced packaging into "the WAR or the executable JAR files" / "your WAR file". The runtime is now a Spring Boot fat JAR only; corrected the language.

### Developer Resources

8. **`developer-resources/java-remote-debugging.md`** — Step 1 was "start the Tomcat server in JPDA (debug) mode with `catalina.sh jpda run`". Replaced with the standalone JAR invocation that the project actually uses: `java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000 -jar dirigible-application-*-executable.jar`. JDWP port 8000 (matching the README/CLAUDE.md guidance). Eclipse and IntelliJ attach steps are unchanged.

### Setup / Kubernetes

9. **`setup/kubernetes/helm.md`** — aligned documented default values with `build/helm-charts/dirigible/values.yaml`:
   - `image.repository`: `dirigiblelabs/dirigible-all` → `dirigiblelabs/dirigible`
   - `database.image`: `postgres:13` → `postgres:14`
   - `database.storage`, `volume.storage`, `keycloak.database.storage`: `1Gi` → `2Gi`
   - `keycloak.image`: `jboss/keycloak:12.0.4` → `jboss/keycloak:16.1.1`

## Out of scope (worth a separate look)

- **`tutorials/customizations/ide/create-view.md`** — beyond the `/services/v4/` strip, this tutorial still references `ide-core/*` asset paths (e.g. `/services/web/ide-core/core/message-hub.js`) that no longer exist after the IDE shell was restructured. The same assets now live under `resources-core` / `platform-core`. Needs a tutorial-aware rewrite rather than a mechanical replace.
- **Helm chart in `eclipse-dirigible/dirigible`** — `build/helm-charts/dirigible/templates/dirigible.yaml:195` uses `/services/v4/healthcheck` as the readiness probe path. That endpoint does not exist in the current Spring Boot runtime (which exposes `/actuator/health/readiness` and `/actuator/health/liveness`). This is a chart bug, not a doc bug; flagging for a separate fix against the main repo.
- **Other auth sections** (`Keycloak`, `Cognito`, `Snowflake`) on the env-vars page — not verified in this pass; may also need an audit.

## Test plan

- [ ] Build the MkDocs site locally (`mkdocs serve` from `docs-help/`) and confirm rewritten sections render correctly (especially the rewritten "OAuth (GitHub)" table, the new engines list, and the architecture overview).
- [ ] Confirm no broken intra-doc links from the URL renames (`grep -r "github.com/eclipse/dirigible" docs-help/docs/` should return zero hits, which it does locally).
- [ ] Spot-check that the JDWP port and Spring Boot JAR path in `java-remote-debugging.md` match what users running the latest `dirigible-application-*-executable.jar` see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
