### PR TITLE
Develop + SDK docs for the Spring-style Java model: new "Coming from Spring Boot" guide, per-language split, annotation-free extensions

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -289,6 +289,7 @@ function helpSidebar() {
       collapsed: true,
       items: [
         { text: 'Overview', link: '/help/develop/' },
+        { text: 'Coming from Spring Boot', link: '/help/develop/coming-from-spring-boot' },
         {
           text: 'Languages',
           collapsed: true,

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -941,6 +941,7 @@ function sdkSidebar() {
           collapsed: true,
           link: '/sdk/component/',
           items: [
+            { text: 'Beans', link: '/sdk/component/beans' },
             { text: 'Decorators', link: '/sdk/component/decorators' },
           ],
         },

--- a/docs/blogs/2026/05/19/dirigible-java-decorators.md
+++ b/docs/blogs/2026/05/19/dirigible-java-decorators.md
@@ -38,7 +38,7 @@ In Dirigible, you write Java like this:
 2. Save.
 3. `curl /services/java/<project>/demo/Country...`
 
-No `mvn package`. No Spring Boot bootstrap. No `target/` directory. The synchronizer notices the file, the engine batch-compiles every client `.java` in the project with one `javac` invocation, the resulting bytecode lands in a fresh `ClientClassLoader`, and consumers fan out to register your classes with the runtime. The previous classloader becomes unreachable; the JVM reclaims its Metaspace at the next GC. **No restart. Ever.**
+No `mvn package`. No Spring Boot bootstrap. No `target/` directory. The synchronizer notices the file, the engine batch-compiles every client `.java` in the project with one `javac` invocation, the resulting bytecode lands in a fresh `ClientClassLoader`, and a single `ComponentContainer` builds and wires your beans and registers them with the runtime. The previous classloader becomes unreachable; the JVM reclaims its Metaspace at the next GC. **No restart. Ever.**
 
 The Force is strong with this one.
 
@@ -49,7 +49,7 @@ The data layer first. Annotate a plain Java class and Hibernate will weave its t
 ```java
 package demo;
 
-import org.eclipse.dirigible.engine.java.annotations.*;
+import org.eclipse.dirigible.sdk.db.*;
 
 @Entity
 @Table(name = "COUNTRIES")
@@ -92,7 +92,7 @@ The recommended pattern is not to call `JavaEntityStore` directly. Subclass `Jav
 package demo;
 
 import org.eclipse.dirigible.components.data.store.java.repository.JavaRepository;
-import org.eclipse.dirigible.engine.java.annotations.Repository;
+import org.eclipse.dirigible.sdk.component.Repository;
 
 @Repository
 public class CountryRepository extends JavaRepository<Country> {
@@ -102,24 +102,26 @@ public class CountryRepository extends JavaRepository<Country> {
 
 `JavaRepository<T>` ships a typed CRUD surface - `save`, `update`, `findById`, `findOne`, `findAll`, `findAll(limit, offset)`, `delete`, `deleteById`, `count`, `query`. Add your own domain methods and they become available everywhere the repository is injected.
 
-The `@Repository` consumer instantiates one singleton per class and stores it in a registry, ready to be handed out.
+A `@Repository` is itself a managed bean - the container builds one singleton per class, ready to be injected anywhere by type.
 
 ## Episode IV: Revenge of the Inject
 
-Spring's `@Autowired` is famously powerful - and famously unavailable to client classes loaded by a foreign `ClassLoader`. So Dirigible brings its own DI resolver, shaped for the hot-reload world.
+Spring's `@Autowired` is famously powerful - and famously unavailable to client classes loaded by a foreign `ClassLoader`. So Dirigible brings its own DI container, shaped for the hot-reload world. **Constructor injection is the preferred style** - declare the collaborators as constructor parameters and the container fills them in by type:
 
 ```java
 package demo;
 
-import org.eclipse.dirigible.engine.java.annotations.Inject;
-import org.eclipse.dirigible.engine.java.annotations.http.*;
+import org.eclipse.dirigible.sdk.http.*;
 
 @Controller
 @Roles({ "DEVELOPER" })
 public class CountryController {
 
-    @Inject
-    private CountryRepository countries;     // ← engine injects the singleton at load time
+    private final CountryRepository countries;
+
+    public CountryController(CountryRepository countries) {   // ← constructor injection
+        this.countries = countries;
+    }
 
     @Get("/")
     public List<Country> list() { return countries.findAll(); }
@@ -136,9 +138,9 @@ public class CountryController {
 }
 ```
 
-When the controller class is loaded, the engine walks every `@Inject` field, queries each registered `DependencyResolver` in order, and writes the result back via reflection. Today the `RepositoryRegistry` is the only resolver - but the surface is open. Future modules can register their own without touching engine-java.
+A single `ComponentContainer` builds every bean per `ClientClassLoader` generation and satisfies constructor parameters, `@Inject` fields, and collection (`List<T>`) injection points by type - independent of declaration order, so `CountryRepository` always resolves within the same rebuild cycle. Field injection with `@Inject` (`org.eclipse.dirigible.sdk.component.Inject`) is available too; constructor injection is preferred. To reach platform services use the `Beans` facade (`Beans.get(Class)`).
 
-No `BeanFactory`. No component scan. Just a typed field that gets filled in.
+No `BeanFactory`. No component scan. Just a typed dependency that gets filled in.
 
 ## Episode V: The Controller Awakens
 
@@ -206,7 +208,7 @@ Edit `Country.java` to add a new column. Save.
 public Long population;
 ```
 
-The synchronizer notices the file change. `javac` rebuilds every client source. A new `ClientClassLoader` is installed. The entity consumer rebuilds the `SessionFactory` with the updated table. The repository consumer instantiates a fresh singleton. The controller consumer resolves `@Inject` against that fresh singleton. The OpenAPI fragment is rewritten. The previous generation becomes unreachable.
+The synchronizer notices the file change. `javac` rebuilds every client source. A new `ClientClassLoader` is installed and a fresh `ComponentContainer` builds every bean: the `SessionFactory` is rebuilt with the updated table, a fresh `CountryRepository` singleton is created, the controller is wired against it (by constructor or `@Inject`, by type), and the OpenAPI fragment is rewritten. The previous generation becomes unreachable.
 
 Your next HTTP request hits the new code. No `mvn`. No `restart`. No deploy pipeline. The same loop your TypeScript colleagues have been smugly demonstrating in standups - now yours.
 

--- a/docs/help/artefacts/extensibility/extension.md
+++ b/docs/help/artefacts/extensibility/extension.md
@@ -25,26 +25,29 @@ Registers a single contribution to a named extension point. Synchronizer: `Exten
 | `module`          | Path to the implementation script (`.ts`, `.js`, or `.mjs`), relative to `/registry/public/`. The contracting point decides what the module must export. |
 | `description`     | Optional. |
 
-## Alternative: typed `@Extension` annotation (Java)
+## Alternative: typed Java contributions
 
-For typed contracts in Java, prefer the annotation pair `@ExtensionPoint` (on the contract interface) + `@Extension(target = ContractInterface.class, name = "...")` (on the contributing class). The runtime validates that the contributing class implements the contract, and consumers receive typed instances via `Extensions.find(Class)` - no string-keyed lookup.
+For typed contracts in Java there is no extension annotation. The **extension point is a plain Java interface**; a **contribution is a `@Component` bean that implements it** - the contribution's name is its `@Component` name. Consumers receive every contribution by type, either through collection injection (`List<MenuContribution>`) or via `Extensions.find(Class)`.
 
 ```java
-import org.eclipse.dirigible.sdk.extensions.Extension;
-import org.eclipse.dirigible.sdk.extensions.ExtensionPoint;
+import java.util.List;
+import java.util.Map;
 
-@ExtensionPoint("Menu contributions")
+import org.eclipse.dirigible.sdk.component.Component;
+
+// The contract: a plain interface, no annotation.
 public interface MenuContribution {
     List<Map<String, Object>> getItems();
 }
 
-@Extension(target = MenuContribution.class, name = "payments-menu")
+// The contribution: a @Component that implements the interface.
+@Component("payments-menu")
 public class PaymentsMenu implements MenuContribution {
     public List<Map<String, Object>> getItems() { /* ... */ }
 }
 ```
 
-The typed Java annotations and the string-keyed `*.extension` artefacts coexist - the `Extensions` facade exposes both lookup styles (see [`/sdk/extensions/extensions`](/sdk/extensions/extensions)).
+A consumer receives all contributions by injecting a `List<MenuContribution>` (preferred) or by calling `Extensions.find(MenuContribution.class)`. The typed Java contributions and the string-keyed `*.extension` artefacts coexist - the `Extensions` facade exposes both lookup styles (see [`/sdk/extensions/extensions`](/sdk/extensions/extensions)).
 
 ## Editor
 

--- a/docs/help/artefacts/extensibility/extensionpoint.md
+++ b/docs/help/artefacts/extensibility/extensionpoint.md
@@ -44,22 +44,27 @@ String[] modules = Extensions.getExtensions("ide-menu");
 
 ## Typed Java alternative
 
-For Java, the preferred form is the annotation pair `@ExtensionPoint` (on the contract interface) + `@Extension(target = ContractInterface.class)` (on contributing classes). Consumers retrieve typed instances directly:
+For Java there is no extension annotation. The **extension point is a plain Java interface**; a **contribution is a `@Component` bean that implements it**. Consumers retrieve typed instances directly - by collection injection (preferred) or `Extensions.find(Class)`:
 
 ```java
-@ExtensionPoint("Menu contributions")
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.extensions.Extensions;
+
+// The contract: a plain interface, no annotation.
 public interface MenuContribution {
     List<Map<String, Object>> getItems();
 }
 
-@Extension(target = MenuContribution.class, name = "payments-menu")
+// The contribution: a @Component that implements the interface.
+@Component("payments-menu")
 public class PaymentsMenu implements MenuContribution { /* ... */ }
 
-// Consumer:
+// Consumer - collection injection (preferred): inject a List<MenuContribution>
+// into a @Controller / @Component constructor, or look them up programmatically:
 List<MenuContribution> menus = Extensions.find(MenuContribution.class);
 ```
 
-See [`/sdk/extensions/decorators`](/sdk/extensions/decorators) and [`/sdk/extensions/extensions`](/sdk/extensions/extensions).
+See [`/sdk/extensions/extensions`](/sdk/extensions/extensions) and [Extension providers](/help/develop/extension-providers).
 
 ## Editor
 

--- a/docs/help/artefacts/process/job.md
+++ b/docs/help/artefacts/process/job.md
@@ -39,19 +39,23 @@ The handler module is invoked synchronously on each fire by the Quartz scheduler
 
 ## Java alternative - `@Scheduled`
 
-A Spring `@Component` carrying `@Scheduled(cron = "...")` is auto-discovered by the platform and runs without a `.job` artefact:
+A client-Java `@Component` with a method-level `@Scheduled(expression = "...")` (the Dirigible annotations under `org.eclipse.dirigible.sdk.*`) is scheduled without a `.job` artefact - note the attribute is `expression`, not `cron`:
 
 ```java
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.job.Scheduled;
+
 @Component
 class CleanupJob {
-    @Scheduled(cron = "0/5 * * * * ?")
+
+    @Scheduled(expression = "0/5 * * * * ?")
     void run() {
         // ...
     }
 }
 ```
 
-`.job` is preferred when the schedule, parameters, or handler should be authored in the registry (and reloaded without a restart). Use `@Scheduled` for platform-internal Spring beans.
+Alternatively, a `@Component` implementing the self-describing `JobHandler` interface carries its own schedule - `String cron()` plus `void run()`. `.job` is preferred when the schedule, parameters, or handler should be authored in the registry (and reloaded without a restart).
 
 ## Tenancy
 

--- a/docs/help/artefacts/scripting/java.md
+++ b/docs/help/artefacts/scripting/java.md
@@ -13,13 +13,9 @@ Client `*.java` sources placed under a project are compiled in-process by [`engi
 
 1. One `javac` task over every client source in the registry.
 2. A single fresh `ClientClassLoader` (parent = platform classloader) replaces the previous generation; old metaspace is GC-reclaimed.
-3. Every loaded class is offered to each `JavaClassConsumer` SPI implementation in `@Order`:
-   - `EntityClassConsumer` (`@Order(100)`) - `@Entity` classes register with Hibernate dynamic-map mode.
-   - `RepositoryClassConsumer` (`@Order(200)`) - `@Repository` classes become singletons in `RepositoryRegistry`.
-   - `ControllerClassConsumer` (`@Order(300)`) - `@Controller` classes register with `ControllerRouter` and publish an OpenAPI fragment.
-   - `HandlerClassConsumer` - `implements JavaHandler` classes register catch-all URL handlers.
+3. A single `ComponentContainer` builds every bean for the new generation. `@Component` makes a class a managed bean - and `@Repository`, `@Controller`, `@Scheduled`, `@Listener`, `@Websocket`, and extension contributions are all `@Component`s. The container instantiates each bean, satisfies constructor, field (`@Inject`), and collection (`List<T>`) injection by type, then registers it with its service: `@Entity` classes with the entity manager (Hibernate dynamic-map mode), `@Controller` routes with the router (plus an OpenAPI fragment), scheduled / listener / websocket beans with their engines.
 
-Cross-file references resolve in user code because every client class shares the same `ClientClassLoader`.
+Injection is order-independent and cross-file references resolve in user code because every client class shares the same `ClientClassLoader` and the same container generation.
 
 ## URL surface
 
@@ -28,38 +24,43 @@ Cross-file references resolve in user code because every client class shares the
 /public/java/{project}/{*classPath}     # anonymous (if enabled)
 ```
 
-`JavaEndpoint.dispatch` tries `ControllerRouter.match` first (longest basePath wins, then most-specific path), then falls through to a `JavaHandler`, then returns 404.
+`JavaEndpoint.dispatch` matches a `@Controller` route first (longest basePath wins, then most-specific path), then falls through to a `JavaHandler`, then returns 404.
 
 ## Annotations
 
-Two annotation packages are on the compile-time classpath of every client `.java`:
+The Java SDK annotations under `org.eclipse.dirigible.sdk.*` are on the compile-time classpath of every client `.java`:
 
-- `org.eclipse.dirigible.engine.java.annotations.*` - persistence: `@Entity`, `@Table`, `@Id`, `@GeneratedValue` (+ `GenerationType`), `@Column`, `@Transient`, `@CreatedAt`, `@UpdatedAt`, `@CreatedBy`, `@UpdatedBy`, `@Documentation`, `@Repository`, `@Inject`.
-- `org.eclipse.dirigible.engine.java.annotations.http.*` - REST: `@Controller`, `@Get`, `@Post`, `@Put`, `@Patch`, `@Delete`, `@Body`, `@PathParam`, `@QueryParam`, `@Context`, `@Roles`.
-
-A class may be exactly one of `{handler, controller}`; carrying both shapes is rejected.
+- `org.eclipse.dirigible.sdk.db.*` - persistence: `@Entity`, `@Table`, `@Id`, `@GeneratedValue` (+ `GenerationType`), `@Column`, `@Transient`, `@CreatedAt`, `@UpdatedAt`, `@CreatedBy`, `@UpdatedBy`, `@Documentation`.
+- `org.eclipse.dirigible.sdk.component.*` - DI: `@Component`, `@Inject`, `@Repository`, plus the `Beans` facade.
+- `org.eclipse.dirigible.sdk.http.*` - REST: `@Controller`, `@Get`, `@Post`, `@Put`, `@Patch`, `@Delete`, `@Body`, `@PathParam`, `@QueryParam`, `@Context`, `@Roles`.
+- `org.eclipse.dirigible.sdk.job.*`, `.listener.*`, `.websocket.*` - method-level `@Scheduled(expression = …)`, `@Listener(name = …, kind = …)`, the `@Websocket` class marker with `@OnOpen` / `@OnMessage` / `@OnClose` / `@OnError`, and the self-describing `JobHandler` / `MessageHandler` / `WebsocketHandler` interfaces.
+- `org.eclipse.dirigible.sdk.extensions.*` - the `Extensions` facade. (A typed Java extension point is just a plain interface; a contribution is a `@Component` that implements it.)
 
 ## Reaching platform beans
 
-Client classes are loaded via `ClientClassLoader`, not Spring-scanned, so `@Autowired` is a no-op. Use `BeanProvider.getBean(...)` from `components-core-base` to fetch `JavaEntityStore`, `IRepository`, etc. The recommended pattern is `@Inject CountryRepository` - resolved by the `DependencyResolver` chain (`RepositoryRegistry` is the only resolver today).
+Client classes are loaded via `ClientClassLoader`, not Spring-scanned, so `@Autowired` is a no-op. To reach platform services from client code use the `Beans` facade - `Beans.get(Class)`, `Beans.get(name, Class)`, `Beans.getAll(Class)` (`org.eclipse.dirigible.sdk.component.Beans`). For entity CRUD the recommended pattern is a `@Repository extends JavaRepository<T>` injected by constructor (or `@Inject` field) into the controller.
 
 ## Example
 
 ```java
 package demo;
 
-import org.eclipse.dirigible.engine.java.annotations.http.Controller;
-import org.eclipse.dirigible.engine.java.annotations.http.Get;
-import org.eclipse.dirigible.engine.java.annotations.Inject;
+import org.eclipse.dirigible.sdk.http.Controller;
+import org.eclipse.dirigible.sdk.http.Get;
+
+import java.util.List;
 
 @Controller
 public class CountryController {
 
-    @Inject
-    private CountryRepository repository;
+    private final CountryRepository repository;
+
+    public CountryController(CountryRepository repository) {
+        this.repository = repository;
+    }
 
     @Get("/list")
-    public Object list() {
+    public List<Country> list() {
         return repository.findAll();
     }
 }

--- a/docs/help/concepts/extensibility.md
+++ b/docs/help/concepts/extensibility.md
@@ -33,18 +33,13 @@ export class Greeter {
 
 Use when: you want Spring-style DI inside user TypeScript.
 
-## Java SPI: `JavaClassConsumer`
+## Java DI container
 
-Every client `.java` class loaded by the platform is offered to every registered `JavaClassConsumer`. Four ship in the box:
+Every client `.java` class compiled by the platform is built into a single `ComponentContainer` per `ClientClassLoader` generation. `@Component` makes a class a managed bean - and `@Repository`, `@Controller`, `@Scheduled`, `@Listener`, `@Websocket`, and extension contributions are all `@Component`s. The container instantiates each bean, satisfies constructor / `@Inject` field / collection (`List<T>`) injection by type, and registers it with its service (`@Entity` to the entity manager, `@Controller` routes to the router + OpenAPI, scheduled / listener / websocket beans to their engines).
 
-- `EntityClassConsumer` (`@Order(100)`) - `@Entity` to `JavaEntityManager`.
-- `RepositoryClassConsumer` (`@Order(200)`) - `@Repository` to `RepositoryRegistry`.
-- `ControllerClassConsumer` (`@Order(300)`) - `@Controller` to `ControllerRouter` + OpenAPI.
-- `HandlerClassConsumer` (LOWEST_PRECEDENCE) - `implements JavaHandler` to `JavaClassRegistry`.
+To consume all implementations of a contract from user code, inject a `List<MyInterface>` or call `Extensions.find(MyInterface.class)`.
 
-To react to compiled client classes - say, you want to claim a custom annotation - implement `JavaClassConsumer`, register it as a Spring `@Component` with a `@Order`, and the existing `JavaSynchronizer.finishing()` cycle picks it up. No second synchronizer required.
-
-Use when: you want to attach behavior to a custom Java annotation in user code.
+Use when: you want Spring-style dependency injection inside user Java, or to wire one client class into another.
 
 ## Custom synchronizer (new artefact type)
 
@@ -111,7 +106,7 @@ To add a new perspective, view, editor, or template, follow the layout of an exi
 | --------------------------------------------------- | ------------------------------------------ |
 | Hook user code into a named platform event          | `.extensionpoint` / `.extension`           |
 | DI inside user TypeScript                           | `*Component.ts`                            |
-| React to compiled client Java classes               | `JavaClassConsumer`                        |
+| DI / wiring inside user Java                        | `@Component` + `@Inject`                   |
 | Add a new artefact type / file extension            | Custom synchronizer                        |
 | Add a new runtime engine                            | New `components/engine/<name>/` module     |
 | Expose Java capability to JS / TS                   | Custom `<Area>Facade` + TS bundle          |
@@ -123,6 +118,6 @@ To add a new perspective, view, editor, or template, follow the layout of an exi
 ## Reference
 
 - [/help/extend/](/help/extend/) - extension-surface authoring guides
-- `JavaClassConsumer` SPI - `components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/spi/`
+- [Dependency injection (develop)](/help/develop/dependency-injection) - the client-Java `@Component` container
 - `Synchronizer` / `BaseSynchronizer` - `components/core/core-base/.../synchronizer/`
 - `CmsProvider`, `ISqlDialect`, `CustomSecurityConfigurator`, `TemplateEngine` - platform SPIs

--- a/docs/help/concepts/lifecycle-and-hot-reload.md
+++ b/docs/help/concepts/lifecycle-and-hot-reload.md
@@ -26,9 +26,9 @@ Java is synchronized by `JavaSynchronizer` (`components/engine/engine-java`), bu
 1. **Parse + persist.** `parseImpl` for each `.java` file upserts the `JavaFile` artefact and enforces global FQN uniqueness. `completeImpl` flips a dirty flag.
 2. **Single `javac` task.** `finishing()` invokes the in-process compiler over **every** client source in one go - cross-file references resolve because they share the same compilation unit.
 3. **Single fresh `ClientClassLoader`.** All compiled classes land in one new classloader, parent = platform classloader. The previous generation becomes unreachable; GC reclaims its Metaspace.
-4. **Consumer fan-out.** Every loaded class is offered to every registered `JavaClassConsumer`, in `@Order` sequence: `EntityClassConsumer` (100), `RepositoryClassConsumer` (200), `ControllerClassConsumer` (300), `HandlerClassConsumer` (LOWEST_PRECEDENCE).
+4. **Container build.** A single `ComponentContainer` builds every bean for the generation. `@Component` (and the meta-annotated `@Repository`, `@Controller`, `@Scheduled`, `@Listener`, `@Websocket`, plus extension contributions) become beans; the container instantiates each, satisfies constructor / `@Inject` field / collection (`List<T>`) injection by type, then registers it with its service (`@Entity` → entity manager, `@Controller` routes → router + OpenAPI, scheduled / listener / websocket beans → their engines).
 
-Result: cross-file references in client code work, `@Inject CountryRepository` resolves inside `ControllerClassConsumer` because `RepositoryClassConsumer` has already registered every repository for that rebuild generation, and old controllers / handlers are atomically swapped for new ones.
+Result: cross-file references in client code work, injection is order-independent (a `@Controller` can depend on any `@Repository` regardless of declaration order, in the constructor or via `@Inject`), and old controllers / handlers are atomically swapped for new ones.
 
 ## Artefact-based engines: STOP / START via the synchronizer
 
@@ -65,5 +65,5 @@ Runs every synchronizer synchronously on the calling thread. See [Publish and re
 - `JavascriptEndpoint`, `TypeScriptEndpoint` - `components/engine/engine-javascript`, `engine-typescript`
 - `JavaSynchronizer` - `components/engine/engine-java/.../synchronizer/JavaSynchronizer.java`
 - `ClientClassLoader`, `ClassPathIndex` - `components/engine/engine-java/.../runtime/`
-- `JavaClassConsumer` SPI - `components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/spi/`
+- `ComponentContainer` (client-Java DI) - `components/engine/engine-java/.../runtime/`
 - `BaseSynchronizer` lifecycle hooks - `components/core/core-base/.../synchronizer/`

--- a/docs/help/concepts/polyglot-runtime.md
+++ b/docs/help/concepts/polyglot-runtime.md
@@ -43,16 +43,18 @@ The same `DatabaseFacade` backs that call whether it comes from JS, TS, or a Jav
 
 ## Calling Java from Java (client to platform)
 
-Client `.java` classes are loaded by `ClientClassLoader`, not Spring-scanned, so `@Autowired` is a no-op on them. Use `BeanProvider.getBean(...)` to pull platform beans from a `@Controller` or `JavaHandler`:
+Client `.java` classes are loaded by `ClientClassLoader`, not Spring-scanned, so `@Autowired` is a no-op on them. Use the `Beans` facade (`org.eclipse.dirigible.sdk.component.Beans`) to pull platform beans from a `@Controller` or `JavaHandler`:
 
 ```java
-import org.eclipse.dirigible.components.base.spring.BeanProvider;
+import org.eclipse.dirigible.sdk.component.Beans;
 import org.eclipse.dirigible.components.data.store.java.store.JavaEntityStore;
 
-JavaEntityStore store = BeanProvider.getBean(JavaEntityStore.class);
+JavaEntityStore store = Beans.get(JavaEntityStore.class);
 ```
+
+`Beans` exposes `get(Class)`, `get(name, Class)`, and `getAll(Class)`; it is the client-facing entry point.
 
 ## Reference
 
 - JS / TS API surface: [`@aerokit/sdk/*`](/api/)
-- Java surface: [`engine-java` annotations + SPI](/help/concepts/extensibility)
+- Java surface: [`org.eclipse.dirigible.sdk.*`](/sdk/)

--- a/docs/help/concepts/publish-and-reconcile.md
+++ b/docs/help/concepts/publish-and-reconcile.md
@@ -55,7 +55,7 @@ JavaScript and TypeScript modules are **not** synchronized - they are loaded on 
 
 ## Special case: client Java
 
-Java is synchronized. The full reconciliation (one `javac` task, one fresh `ClientClassLoader`, all `JavaClassConsumer`s) runs inside `JavaSynchronizer.finishing()` once per cycle. Publish a Java file - it takes up to one cycle to compile and reload.
+Java is synchronized. The full reconciliation (one `javac` task, one fresh `ClientClassLoader`, a single `ComponentContainer` that builds and wires every bean) runs inside `JavaSynchronizer.finishing()` once per cycle. Publish a Java file - it takes up to one cycle to compile and reload.
 
 ## Forcing a sync
 

--- a/docs/help/concepts/repository-and-workspace.md
+++ b/docs/help/concepts/repository-and-workspace.md
@@ -47,7 +47,7 @@ With `DIRIGIBLE_MULTI_TENANT_MODE=true` (the default), tenant-scoped artefacts a
 From client code:
 
 - JS / TS: [`@aerokit/sdk/platform/repository-client`](/api/platform), [`@aerokit/sdk/platform/workspace-client`](/api/platform).
-- Java: `BeanProvider.getBean(IRepository.class)` then `repository.getResource(path)` / `getCollection(path)` / `createResource(...)`.
+- Java: `Beans.get(IRepository.class)` (`org.eclipse.dirigible.sdk.component.Beans`) then `repository.getResource(path)` / `getCollection(path)` / `createResource(...)`.
 
 In HTTP-only integration tests, write fixture files directly via `IRepository.createResource(...)` and then call `SynchronizationProcessor.forceProcessSynchronizers()` to trigger reconciliation synchronously.
 

--- a/docs/help/concepts/synchronizer-model.md
+++ b/docs/help/concepts/synchronizer-model.md
@@ -60,7 +60,7 @@ JS and TS user code is **not** synchronized. `JavascriptEndpoint` and `TypeScrip
 
 ## Special case: client Java
 
-Client `.java` files **are** synchronized, but the heavy work (one `javac` task, one fresh `ClientClassLoader`, consumer fan-out) happens inside `JavaSynchronizer.finishing()`. The `JavaClassConsumer` SPI plugs custom behavior into that fan-out - see [Extensibility](/help/concepts/extensibility).
+Client `.java` files **are** synchronized, but the heavy work (one `javac` task, one fresh `ClientClassLoader`, a single `ComponentContainer` that builds and wires every bean) happens inside `JavaSynchronizer.finishing()`. `@Component` (and the meta-annotated `@Repository` / `@Controller` / `@Scheduled` / `@Listener` / `@Websocket`) drives that wiring - see [Extensibility](/help/concepts/extensibility).
 
 ## Reference
 

--- a/docs/help/develop/coming-from-spring-boot.md
+++ b/docs/help/develop/coming-from-spring-boot.md
@@ -33,142 +33,170 @@ The big mental shift: your `.java` files are **client code** that the platform c
 
 ## Side-by-side: implementing each artifact
 
-For jobs, listeners, and websockets Dirigible offers **two styles**: a self-describing **strong interface**, or **method-level annotations** on a `@Component`. A single `@Component` class uses one style or the other - never both. Pick the interface style when the class *is* the handler; pick the annotation style when you want several handlers (or injected collaborators) on one bean.
+Each artifact is shown the **Spring way first, then the Dirigible way**, so you can see how close they are. For jobs, listeners, and websockets there are **two styles** - a self-describing **strong interface** or **method-level annotations** on a `@Component` - and a single `@Component` class uses one or the other, never both. The main difference: in Spring the interface style gets its binding (destination / cron / path) from separate configuration, whereas the Dirigible interface is **self-describing** (the binding is a method on the interface).
 
 ### Listener
 
-**Strong interface** - implement `MessageHandler`, supply your own `destination()`:
+**Strong interface.** Spring - implement `jakarta.jms.MessageListener` (the destination is set on the listener container in config):
+
+```java
+@Component
+class OrderListener implements MessageListener {
+    public void onMessage(Message message) { /* ... */ }
+}
+```
+
+Dirigible - implement `MessageHandler` and supply your own `destination()`:
 
 ```java
 @Component
 public class OrderListener implements MessageHandler {
+    @Override
+    public String destination() { return "java-order-queue"; }
 
     @Override
-    public String destination() {
-        return "java-order-queue";
-    }
-
-    @Override
-    public void onMessage(String message) {
-        LOGGER.info("OrderListener received: {}", message);
-    }
+    public void onMessage(String message) { LOGGER.info("received: {}", message); }
 }
 ```
 
-**Method-level** - `@Listener` on a `@Component` method (Spring's `@JmsListener` shape):
+**Method-level.** Spring - `@JmsListener` on a bean method:
+
+```java
+@Component
+class Invoices {
+    @JmsListener(destination = "java-invoice-queue")
+    void onInvoice(String message) { /* ... */ }
+}
+```
+
+Dirigible - `@Listener` on a `@Component` method:
 
 ```java
 @Component
 public class InvoiceListener {
-
-    private final Auditor auditor;
-
-    public InvoiceListener(Auditor auditor) {
-        this.auditor = auditor;
-    }
-
     @Listener(name = "java-invoice-queue", kind = ListenerKind.QUEUE)
-    public void onInvoice(String message) {
-        auditor.record("invoice received: " + message);
-    }
+    public void onInvoice(String message) { /* ... */ }
 }
 ```
 
-Sample: [`dirigiblelabs/sample-java-listener-decorator`](https://github.com/dirigiblelabs/sample-java-listener-decorator) (branch `feat/spring-style-listeners`).
+Sample: [`dirigiblelabs/sample-java-listener-decorator`](https://github.com/dirigiblelabs/sample-java-listener-decorator).
 
 ### Job
 
-**Strong interface** - implement `JobHandler`, supply your own `cron()`:
+**Strong interface.** Spring - implement Quartz `org.quartz.Job` (the cron lives in a `Trigger` bean):
+
+```java
+public class CleanupJob implements Job {
+    public void execute(JobExecutionContext context) { /* ... */ }
+}
+```
+
+Dirigible - implement `JobHandler` and supply your own `cron()`:
 
 ```java
 @Component
 public class CleanupJob implements JobHandler {
+    @Override
+    public String cron() { return "* * * * * ?"; }
 
     @Override
-    public String cron() {
-        return "* * * * * ?";
-    }
-
-    @Override
-    public void run() {
-        LOGGER.info("CleanupJob executed!");
-    }
+    public void run() { LOGGER.info("CleanupJob executed!"); }
 }
 ```
 
-**Method-level** - `@Scheduled` on a `@Component` method:
+**Method-level.** Spring - `@Scheduled` on a bean method:
+
+```java
+@Component
+class Maintenance {
+    @Scheduled(cron = "0/45 * * * * ?")
+    void purgeTempFiles() { /* ... */ }
+}
+```
+
+Dirigible - `@Scheduled` on a `@Component` method (`expression` instead of `cron`):
 
 ```java
 @Component
 public class Maintenance {
-
     @Scheduled(expression = "0/45 * * * * ?")
-    public void purgeTempFiles() {
-        LOGGER.info("Maintenance.purgeTempFiles executed!");
-    }
+    public void purgeTempFiles() { /* ... */ }
 }
 ```
 
-Sample: [`dirigiblelabs/sample-java-job-decorator`](https://github.com/dirigiblelabs/sample-java-job-decorator) (branch `feat/spring-style-jobs`).
+Sample: [`dirigiblelabs/sample-java-job-decorator`](https://github.com/dirigiblelabs/sample-java-job-decorator).
 
 ### WebSocket
 
-**Strong interface** - implement `WebsocketHandler`, supply your own `endpoint()`; override only the callbacks you need:
+**Strong interface.** Spring - extend `TextWebSocketHandler` (the path is registered in config):
+
+```java
+@Component
+class ChatHandler extends TextWebSocketHandler {
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) { /* ... */ }
+}
+```
+
+Dirigible - implement `WebsocketHandler` and supply your own `endpoint()`; override only what you need:
 
 ```java
 @Component
 public class ChatHandler implements WebsocketHandler {
+    @Override
+    public String endpoint() { return "java-chat"; }
 
     @Override
-    public String endpoint() {
-        return "java-chat";
-    }
-
-    @Override
-    public void onMessage(String message, String from) {
-        System.out.println("ChatHandler: " + from + " says: " + message);
-    }
+    public void onMessage(String message, String from) { /* ... */ }
 }
 ```
 
-**Annotation** - `@Websocket(endpoint = …)` class with `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose` methods (a non-void `@OnMessage` return is sent back to the client):
+**Annotation.** Spring / Jakarta - `@ServerEndpoint` class with `@OnOpen` / `@OnMessage`:
+
+```java
+@ServerEndpoint("/java-ticker")
+public class TickerHandler {
+    @OnOpen    public void opened(Session session) { /* ... */ }
+    @OnMessage public String message(String message) { return "tick: " + message; }
+}
+```
+
+Dirigible - `@Websocket(endpoint = …)` class with `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose` (a non-void `@OnMessage` return is sent back to the client):
 
 ```java
 @Websocket(name = "Java Ticker", endpoint = "java-ticker")
 public class TickerHandler {
-
-    @OnOpen
-    public void opened() {
-        System.out.println("TickerHandler: client connected");
-    }
-
-    @OnMessage
-    public String message(String message, String from) {
-        return "tick: " + message;
-    }
+    @OnOpen    public void opened() { /* ... */ }
+    @OnMessage public String message(String message, String from) { return "tick: " + message; }
 }
 ```
 
-Sample: [`dirigiblelabs/sample-java-websocket-decorator`](https://github.com/dirigiblelabs/sample-java-websocket-decorator) (branch `feat/spring-style-websockets`).
+Sample: [`dirigiblelabs/sample-java-websocket-decorator`](https://github.com/dirigiblelabs/sample-java-websocket-decorator).
 
 ### Controller
 
-A `@Controller` with method-level verb annotations; the return value is serialized as the response body:
+Spring - `@RestController` with constructor injection:
+
+```java
+@RestController
+class CountryController {
+    private final CountryRepository countries;
+    CountryController(CountryRepository countries) { this.countries = countries; }
+
+    @GetMapping("/{id}")
+    Country find(@PathVariable long id) { return countries.findById(id).orElseThrow(); }
+}
+```
+
+Dirigible - `@Controller`; the return value is serialized as the response body:
 
 ```java
 @Controller
 public class CountryController {
-
     private final CountryRepository countries;
-
-    public CountryController(CountryRepository countries) {
-        this.countries = countries;
-    }
+    public CountryController(CountryRepository countries) { this.countries = countries; }
 
     @Get("/{id}")
-    public Country find(@PathParam("id") long id) {
-        return countries.findById(id);
-    }
+    public Country find(@PathParam("id") long id) { return countries.findById(id); }
 }
 ```
 
@@ -176,53 +204,61 @@ See [REST APIs](/help/develop/rest-apis).
 
 ### Repository
 
-A **concrete class** extending `JavaRepository<T>`, marked `@Repository` (not a Spring-Data interface). You get typed CRUD plus `query(hql, params)`:
+Spring Data - declare an interface, the framework generates the implementation:
+
+```java
+interface CountryRepository extends JpaRepository<Country, Long> { }
+```
+
+Dirigible - a **concrete class** extending `JavaRepository<T>`, marked `@Repository` (typed CRUD plus `query(hql, params)`):
 
 ```java
 @Repository
-public class CountryRepository extends JavaRepository<Country> {
-}
+public class CountryRepository extends JavaRepository<Country> { }
 ```
 
 See [Entities and persistence](/help/develop/entities-and-persistence).
 
 ### Extension
 
-No annotation: the **extension point is a plain interface**, a **contribution is a `@Component`** implementing it, and consumers receive all contributions via `List<…>` injection:
+The shape is the same in both: an interface, `@Component` implementations, and a consumer that injects `List<Interface>` to receive them all.
+
+Spring:
 
 ```java
-public interface SampleExtensionPoint {
-    String describe();
+interface SampleExtensionPoint { String describe(); }
+
+@Component
+class SampleContribution implements SampleExtensionPoint {
+    public String describe() { return "Hello from SampleContribution!"; }
 }
+
+@RestController
+class InjectingConsumer {
+    private final List<SampleExtensionPoint> contributions;
+    InjectingConsumer(List<SampleExtensionPoint> contributions) { this.contributions = contributions; }
+}
+```
+
+Dirigible (no dedicated annotation - the `@Component` name is the contribution name):
+
+```java
+public interface SampleExtensionPoint { String describe(); }
 
 @Component("sample-contribution")
 public class SampleContribution implements SampleExtensionPoint {
     @Override
-    public String describe() {
-        return "Hello from SampleContribution!";
-    }
+    public String describe() { return "Hello from SampleContribution!"; }
 }
 
 @Controller
 public class InjectingConsumer {
-
     private final List<SampleExtensionPoint> contributions;
-
-    public InjectingConsumer(List<SampleExtensionPoint> contributions) {
-        this.contributions = contributions;
-    }
+    public InjectingConsumer(List<SampleExtensionPoint> contributions) { this.contributions = contributions; }
 }
 ```
 
-Sample: [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator) (branch `feat/spring-style-extension-injection`). See [Extension providers](/help/develop/extension-providers).
-
-## Key differences
-
-1. **Two handler styles, never mixed on one `@Component`.** For jobs, listeners, and websockets you either implement the self-describing interface (`JobHandler` / `MessageHandler` / `WebsocketHandler`) **or** use method-level annotations (`@Scheduled` / `@Listener` / `@OnMessage` …). The engine rejects a class that carries both shapes.
-2. **Repositories are concrete classes.** `JavaRepository<T>` gives you typed `findAll`, `findById`, `save`, `update`, `delete`, `deleteById`, `count`, and `query`. There are no Spring-Data derived query methods - write HQL via `query(hql, params)` for anything beyond CRUD.
-3. **Singleton scope only.** Every bean is a single instance per classloader generation. There is no `prototype` / `request` / `session` scope.
-4. **No declarative `@Transactional` yet.** Transactions are managed by the repository / store operations; there is no method-level transaction demarcation annotation.
-5. **Client code is not Spring-scanned.** Your classes are loaded by `ClientClassLoader`, not picked up by `@ComponentScan`, so `@Autowired` does nothing. Use `@Inject` / constructor injection between your own beans and `Beans.get(...)` to reach platform services.
+Sample: [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator). See [Extension providers](/help/develop/extension-providers).
 
 ## Where to go next
 

--- a/docs/help/develop/coming-from-spring-boot.md
+++ b/docs/help/develop/coming-from-spring-boot.md
@@ -49,8 +49,15 @@ class OrderListener implements MessageListener {
 Dirigible - implement `MessageHandler` and supply your own `destination()`:
 
 ```java
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.messaging.MessageHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 @Component
 public class OrderListener implements MessageHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger("app.out");
+
     @Override
     public String destination() { return "java-order-queue"; }
 
@@ -72,6 +79,10 @@ class Invoices {
 Dirigible - `@Listener` on a `@Component` method:
 
 ```java
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.messaging.Listener;
+import org.eclipse.dirigible.sdk.messaging.ListenerKind;
+
 @Component
 public class InvoiceListener {
     @Listener(name = "java-invoice-queue", kind = ListenerKind.QUEUE)
@@ -94,8 +105,15 @@ public class CleanupJob implements Job {
 Dirigible - implement `JobHandler` and supply your own `cron()`:
 
 ```java
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.job.JobHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 @Component
 public class CleanupJob implements JobHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger("app.out");
+
     @Override
     public String cron() { return "* * * * * ?"; }
 
@@ -117,6 +135,9 @@ class Maintenance {
 Dirigible - `@Scheduled` on a `@Component` method (`expression` instead of `cron`):
 
 ```java
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.job.Scheduled;
+
 @Component
 public class Maintenance {
     @Scheduled(expression = "0/45 * * * * ?")
@@ -140,6 +161,9 @@ class ChatHandler extends TextWebSocketHandler {
 Dirigible - implement `WebsocketHandler` and supply your own `endpoint()`; override only what you need:
 
 ```java
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.net.WebsocketHandler;
+
 @Component
 public class ChatHandler implements WebsocketHandler {
     @Override
@@ -163,6 +187,10 @@ public class TickerHandler {
 Dirigible - `@Websocket(endpoint = …)` class with `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose` (a non-void `@OnMessage` return is sent back to the client):
 
 ```java
+import org.eclipse.dirigible.sdk.net.OnMessage;
+import org.eclipse.dirigible.sdk.net.OnOpen;
+import org.eclipse.dirigible.sdk.net.Websocket;
+
 @Websocket(name = "Java Ticker", endpoint = "java-ticker")
 public class TickerHandler {
     @OnOpen    public void opened() { /* ... */ }
@@ -190,6 +218,10 @@ class CountryController {
 Dirigible - `@Controller`; the return value is serialized as the response body:
 
 ```java
+import org.eclipse.dirigible.sdk.http.Controller;
+import org.eclipse.dirigible.sdk.http.Get;
+import org.eclipse.dirigible.sdk.http.PathParam;
+
 @Controller
 public class CountryController {
     private final CountryRepository countries;
@@ -213,8 +245,13 @@ interface CountryRepository extends JpaRepository<Country, Long> { }
 Dirigible - a **concrete class** extending `JavaRepository<T>`, marked `@Repository` (typed CRUD plus `query(hql, params)`):
 
 ```java
+import org.eclipse.dirigible.sdk.component.Repository;
+import org.eclipse.dirigible.components.data.store.java.repository.JavaRepository;
+
 @Repository
-public class CountryRepository extends JavaRepository<Country> { }
+public class CountryRepository extends JavaRepository<Country> {
+    public CountryRepository() { super(Country.class); }
+}
 ```
 
 See [Entities and persistence](/help/develop/entities-and-persistence).
@@ -243,6 +280,11 @@ class InjectingConsumer {
 Dirigible (no dedicated annotation - the `@Component` name is the contribution name):
 
 ```java
+import java.util.List;
+
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.http.Controller;
+
 public interface SampleExtensionPoint { String describe(); }
 
 @Component("sample-contribution")

--- a/docs/help/develop/coming-from-spring-boot.md
+++ b/docs/help/develop/coming-from-spring-boot.md
@@ -31,6 +31,191 @@ The big mental shift: your `.java` files are **client code** that the platform c
 | Spring Security context / principal | `User` (`sdk.security.User`) | Static accessors for the current user. |
 | `@PostConstruct` / `@PreDestroy` | `@PostConstruct` / `@PreDestroy` (`jakarta.annotation`) | Same lifecycle callbacks. |
 
+## Side-by-side: implementing each artifact
+
+For jobs, listeners, and websockets Dirigible offers **two styles**: a self-describing **strong interface**, or **method-level annotations** on a `@Component`. A single `@Component` class uses one style or the other - never both. Pick the interface style when the class *is* the handler; pick the annotation style when you want several handlers (or injected collaborators) on one bean.
+
+### Listener
+
+**Strong interface** - implement `MessageHandler`, supply your own `destination()`:
+
+```java
+@Component
+public class OrderListener implements MessageHandler {
+
+    @Override
+    public String destination() {
+        return "java-order-queue";
+    }
+
+    @Override
+    public void onMessage(String message) {
+        LOGGER.info("OrderListener received: {}", message);
+    }
+}
+```
+
+**Method-level** - `@Listener` on a `@Component` method (Spring's `@JmsListener` shape):
+
+```java
+@Component
+public class InvoiceListener {
+
+    private final Auditor auditor;
+
+    public InvoiceListener(Auditor auditor) {
+        this.auditor = auditor;
+    }
+
+    @Listener(name = "java-invoice-queue", kind = ListenerKind.QUEUE)
+    public void onInvoice(String message) {
+        auditor.record("invoice received: " + message);
+    }
+}
+```
+
+Sample: [`dirigiblelabs/sample-java-listener-decorator`](https://github.com/dirigiblelabs/sample-java-listener-decorator) (branch `feat/spring-style-listeners`).
+
+### Job
+
+**Strong interface** - implement `JobHandler`, supply your own `cron()`:
+
+```java
+@Component
+public class CleanupJob implements JobHandler {
+
+    @Override
+    public String cron() {
+        return "* * * * * ?";
+    }
+
+    @Override
+    public void run() {
+        LOGGER.info("CleanupJob executed!");
+    }
+}
+```
+
+**Method-level** - `@Scheduled` on a `@Component` method:
+
+```java
+@Component
+public class Maintenance {
+
+    @Scheduled(expression = "0/45 * * * * ?")
+    public void purgeTempFiles() {
+        LOGGER.info("Maintenance.purgeTempFiles executed!");
+    }
+}
+```
+
+Sample: [`dirigiblelabs/sample-java-job-decorator`](https://github.com/dirigiblelabs/sample-java-job-decorator) (branch `feat/spring-style-jobs`).
+
+### WebSocket
+
+**Strong interface** - implement `WebsocketHandler`, supply your own `endpoint()`; override only the callbacks you need:
+
+```java
+@Component
+public class ChatHandler implements WebsocketHandler {
+
+    @Override
+    public String endpoint() {
+        return "java-chat";
+    }
+
+    @Override
+    public void onMessage(String message, String from) {
+        System.out.println("ChatHandler: " + from + " says: " + message);
+    }
+}
+```
+
+**Annotation** - `@Websocket(endpoint = …)` class with `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose` methods (a non-void `@OnMessage` return is sent back to the client):
+
+```java
+@Websocket(name = "Java Ticker", endpoint = "java-ticker")
+public class TickerHandler {
+
+    @OnOpen
+    public void opened() {
+        System.out.println("TickerHandler: client connected");
+    }
+
+    @OnMessage
+    public String message(String message, String from) {
+        return "tick: " + message;
+    }
+}
+```
+
+Sample: [`dirigiblelabs/sample-java-websocket-decorator`](https://github.com/dirigiblelabs/sample-java-websocket-decorator) (branch `feat/spring-style-websockets`).
+
+### Controller
+
+A `@Controller` with method-level verb annotations; the return value is serialized as the response body:
+
+```java
+@Controller
+public class CountryController {
+
+    private final CountryRepository countries;
+
+    public CountryController(CountryRepository countries) {
+        this.countries = countries;
+    }
+
+    @Get("/{id}")
+    public Country find(@PathParam("id") long id) {
+        return countries.findById(id);
+    }
+}
+```
+
+See [REST APIs](/help/develop/rest-apis).
+
+### Repository
+
+A **concrete class** extending `JavaRepository<T>`, marked `@Repository` (not a Spring-Data interface). You get typed CRUD plus `query(hql, params)`:
+
+```java
+@Repository
+public class CountryRepository extends JavaRepository<Country> {
+}
+```
+
+See [Entities and persistence](/help/develop/entities-and-persistence).
+
+### Extension
+
+No annotation: the **extension point is a plain interface**, a **contribution is a `@Component`** implementing it, and consumers receive all contributions via `List<…>` injection:
+
+```java
+public interface SampleExtensionPoint {
+    String describe();
+}
+
+@Component("sample-contribution")
+public class SampleContribution implements SampleExtensionPoint {
+    @Override
+    public String describe() {
+        return "Hello from SampleContribution!";
+    }
+}
+
+@Controller
+public class InjectingConsumer {
+
+    private final List<SampleExtensionPoint> contributions;
+
+    public InjectingConsumer(List<SampleExtensionPoint> contributions) {
+        this.contributions = contributions;
+    }
+}
+```
+
+Sample: [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator) (branch `feat/spring-style-extension-injection`). See [Extension providers](/help/develop/extension-providers).
+
 ## Key differences
 
 1. **Two handler styles, never mixed on one `@Component`.** For jobs, listeners, and websockets you either implement the self-describing interface (`JobHandler` / `MessageHandler` / `WebsocketHandler`) **or** use method-level annotations (`@Scheduled` / `@Listener` / `@OnMessage` …). The engine rejects a class that carries both shapes.

--- a/docs/help/develop/coming-from-spring-boot.md
+++ b/docs/help/develop/coming-from-spring-boot.md
@@ -40,6 +40,10 @@ Each artifact is shown the **Spring way first, then the Dirigible way**, so you 
 **Strong interface.** Spring - implement `jakarta.jms.MessageListener` (the destination is set on the listener container in config):
 
 ```java
+import jakarta.jms.Message;
+import jakarta.jms.MessageListener;
+import org.springframework.stereotype.Component;
+
 @Component
 class OrderListener implements MessageListener {
     public void onMessage(Message message) { /* ... */ }
@@ -69,6 +73,9 @@ public class OrderListener implements MessageHandler {
 **Method-level.** Spring - `@JmsListener` on a bean method:
 
 ```java
+import org.springframework.jms.annotation.JmsListener;
+import org.springframework.stereotype.Component;
+
 @Component
 class Invoices {
     @JmsListener(destination = "java-invoice-queue")
@@ -97,6 +104,9 @@ Sample: [`dirigiblelabs/sample-java-listener-decorator`](https://github.com/diri
 **Strong interface.** Spring - implement Quartz `org.quartz.Job` (the cron lives in a `Trigger` bean):
 
 ```java
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+
 public class CleanupJob implements Job {
     public void execute(JobExecutionContext context) { /* ... */ }
 }
@@ -125,6 +135,9 @@ public class CleanupJob implements JobHandler {
 **Method-level.** Spring - `@Scheduled` on a bean method:
 
 ```java
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
 @Component
 class Maintenance {
     @Scheduled(cron = "0/45 * * * * ?")
@@ -152,6 +165,11 @@ Sample: [`dirigiblelabs/sample-java-job-decorator`](https://github.com/dirigible
 **Strong interface.** Spring - extend `TextWebSocketHandler` (the path is registered in config):
 
 ```java
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
 @Component
 class ChatHandler extends TextWebSocketHandler {
     protected void handleTextMessage(WebSocketSession session, TextMessage message) { /* ... */ }
@@ -177,6 +195,11 @@ public class ChatHandler implements WebsocketHandler {
 **Annotation.** Spring / Jakarta - `@ServerEndpoint` class with `@OnOpen` / `@OnMessage`:
 
 ```java
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
+
 @ServerEndpoint("/java-ticker")
 public class TickerHandler {
     @OnOpen    public void opened(Session session) { /* ... */ }
@@ -205,6 +228,10 @@ Sample: [`dirigiblelabs/sample-java-websocket-decorator`](https://github.com/dir
 Spring - `@RestController` with constructor injection:
 
 ```java
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
 @RestController
 class CountryController {
     private final CountryRepository countries;
@@ -239,6 +266,8 @@ See [REST APIs](/help/develop/rest-apis).
 Spring Data - declare an interface, the framework generates the implementation:
 
 ```java
+import org.springframework.data.jpa.repository.JpaRepository;
+
 interface CountryRepository extends JpaRepository<Country, Long> { }
 ```
 
@@ -263,6 +292,11 @@ The shape is the same in both: an interface, `@Component` implementations, and a
 Spring:
 
 ```java
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RestController;
+
 interface SampleExtensionPoint { String describe(); }
 
 @Component

--- a/docs/help/develop/coming-from-spring-boot.md
+++ b/docs/help/develop/coming-from-spring-boot.md
@@ -1,0 +1,49 @@
+---
+title: Coming from Spring Boot
+description: A fast-start map from Spring Boot concepts to the Dirigible client-Java model.
+---
+
+# Coming from Spring Boot
+
+If you know Spring Boot, the Dirigible Java model will feel familiar: you annotate a class or method to declare intent, and the platform wires it into DI, routing, persistence, scheduling, messaging, websockets, and security. The annotations live under `org.eclipse.dirigible.sdk.*` and deliberately mirror their Spring / Jakarta counterparts.
+
+The big mental shift: your `.java` files are **client code** that the platform compiles in-process and loads through its own classloader. They are **not** part of Spring's component scan, so `@Autowired` is a no-op on them - you use Dirigible's own (Spring-shaped) DI surface instead.
+
+## Mapping table
+
+| Spring / Jakarta | Dirigible | Note |
+| --- | --- | --- |
+| `@Component` | `@Component` (`sdk.component`) | Same idea; default bean name is the decapitalized class name. |
+| `@Autowired` field / constructor | `@Inject` field / constructor injection | Constructor injection is preferred. |
+| `List<T>` injection | `List<T>` injection | Receives **every** bean assignable to `T`. |
+| `ApplicationContext.getBean(...)` | `Beans.get(...)` / `Beans.get(name, ...)` / `Beans.getAll(...)` (`sdk.component.Beans`) | Client-facing facade - not the platform-internal `BeanProvider`. |
+| `@RestController` | `@Controller` (`sdk.http`) | Return value is serialized as the response body. |
+| `@GetMapping` / `@PostMapping` / `@PutMapping` / `@PatchMapping` / `@DeleteMapping` | `@Get` / `@Post` / `@Put` / `@Patch` / `@Delete` (`sdk.http`) | Method-level; `value()` is the path suffix with `{name}` placeholders. |
+| `@PathVariable` / `@RequestParam` / `@RequestBody` | `@PathParam` / `@QueryParam` / `@Body` (`sdk.http`) | Same parameter-binding roles. |
+| `interface … extends JpaRepository<T, ID>` | `class … extends JavaRepository<T>` + `@Repository` | A **concrete class**, not an interface. No derived queries - use `query(hql, params)`. |
+| `org.quartz.Job` (interface) | `JobHandler` (`sdk.job`) - self-describing `cron()` + `run()` | Strong-interface job style. |
+| `@Scheduled(cron = …)` on a method | `@Scheduled(expression = …)` on a `@Component` method | Method-level scheduling style. |
+| `jakarta.jms.MessageListener` | `MessageHandler` (`sdk.messaging`) - self-describing `destination()` / `kind()` + `onMessage` | Strong-interface listener style. |
+| `@JmsListener(destination = …)` on a method | `@Listener(name = …, kind = …)` on a `@Component` method | Method-level listener style. |
+| `TextWebSocketHandler` | `WebsocketHandler` (`sdk.net`) - self-describing `endpoint()` + callbacks | Strong-interface websocket style. |
+| Jakarta `@ServerEndpoint` + `@OnMessage` | `@Websocket(endpoint = …)` class + `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose` | Method-level callback style. |
+| `@RolesAllowed` / `@PreAuthorize` | `@Roles` (`sdk.security`) | Any-of role check on a class or method. |
+| Spring Security context / principal | `User` (`sdk.security.User`) | Static accessors for the current user. |
+| `@PostConstruct` / `@PreDestroy` | `@PostConstruct` / `@PreDestroy` (`jakarta.annotation`) | Same lifecycle callbacks. |
+
+## Key differences
+
+1. **Two handler styles, never mixed on one `@Component`.** For jobs, listeners, and websockets you either implement the self-describing interface (`JobHandler` / `MessageHandler` / `WebsocketHandler`) **or** use method-level annotations (`@Scheduled` / `@Listener` / `@OnMessage` …). The engine rejects a class that carries both shapes.
+2. **Repositories are concrete classes.** `JavaRepository<T>` gives you typed `findAll`, `findById`, `save`, `update`, `delete`, `deleteById`, `count`, and `query`. There are no Spring-Data derived query methods - write HQL via `query(hql, params)` for anything beyond CRUD.
+3. **Singleton scope only.** Every bean is a single instance per classloader generation. There is no `prototype` / `request` / `session` scope.
+4. **No declarative `@Transactional` yet.** Transactions are managed by the repository / store operations; there is no method-level transaction demarcation annotation.
+5. **Client code is not Spring-scanned.** Your classes are loaded by `ClientClassLoader`, not picked up by `@ComponentScan`, so `@Autowired` does nothing. Use `@Inject` / constructor injection between your own beans and `Beans.get(...)` to reach platform services.
+
+## Where to go next
+
+- [Dependency injection](/help/develop/dependency-injection) - `@Component`, `@Inject`, `Beans`.
+- [REST APIs](/help/develop/rest-apis) - `@Controller` + the method verbs.
+- [Entities and persistence](/help/develop/entities-and-persistence) - `@Entity`, `@Repository`, `JavaRepository`.
+- [Scheduled jobs](/help/develop/scheduled-jobs), [Message listeners](/help/develop/message-listeners), [Websockets](/help/develop/websockets), [Extension providers](/help/develop/extension-providers).
+- [Security and roles](/help/develop/security-and-roles) - `@Roles` and the `User` API.
+- [SDK reference](https://www.dirigible.io/sdk/).

--- a/docs/help/develop/decorators-model.md
+++ b/docs/help/develop/decorators-model.md
@@ -21,9 +21,9 @@ Dirigible's modern development model is **decorator-driven on TypeScript** and *
 | Managed bean | `@Component("Name")` | `@Component` (optional name) |
 | Repository / DI | `@Component("CountryRepository")` | `@Repository` (a `@Component`) |
 | Inject | `@Inject("CountryRepository")` | `@Inject` (field / constructor / parameter) or constructor injection |
-| Scheduled job | `@Scheduled(...)` | `@Scheduled` on a class implementing `JobHandler`, or on a method of a `@Component` |
-| Message listener | `@Listener(...)` | `@Listener` on a class implementing `MessageHandler`, or on a method of a `@Component` |
-| Websocket | `@Websocket(...)` | `@Websocket` on a class implementing `WebsocketHandler`, or `@OnOpen`/`@OnMessage`/`@OnError`/`@OnClose` methods of a `@Component` |
+| Scheduled job | `@Scheduled(...)` | `@Component` implementing `JobHandler` (self-describing `cron()`), or `@Scheduled` on a method of a `@Component` |
+| Message listener | `@Listener(...)` | `@Component` implementing `MessageHandler` (self-describing `destination()`/`kind()`), or `@Listener` on a method of a `@Component` |
+| Websocket | `@Websocket(...)` | `@Component` implementing `WebsocketHandler` (self-describing `endpoint()`), or a `@Websocket` class with `@OnOpen`/`@OnMessage`/`@OnError`/`@OnClose` methods |
 | Extension point | `@ExtensionPoint("description")` on an interface | `@ExtensionPoint("description")` on an interface |
 | Extension provider | `@Extension({target: Contract})` | `@Extension(target=Contract.class, name="...")` |
 | Role check | `@Roles(["admin"])` | `@Roles({"admin"})` |
@@ -34,9 +34,14 @@ The mechanism behind each declaration is the same: at class-load time the platfo
 
 On the Java side a single `ComponentContainer` builds all beans per `ClientClassLoader` generation. Because `@Repository`, `@Controller`, `@Scheduled`, `@Listener`, `@Websocket`, and `@Extension` are all meta-annotated `@Component`, they are beans too - the container instantiates them, satisfies constructor / field / collection injection by type, and then registers each with its service (`@Entity` → `JavaEntityManager`, `@Controller` routes → `ControllerRouter`, and so on). Injection is order-independent: any bean can depend on any other regardless of declaration order, so `@Inject CountryRepository` (or a `CountryRepository` constructor parameter) always resolves within the same rebuild cycle.
 
-### Strong interfaces or method-level annotations
+### Two handler styles - never mixed
 
-`@Scheduled`, `@Listener`, and `@Websocket` each ship a companion interface in the SDK (`JobHandler`, `MessageHandler`, `WebsocketHandler`) - implement it for compile-time signature checking, IDE autocomplete, default no-op callbacks, and direct (non-reflective) dispatch. Alternatively, annotate a **method** of a `@Component` bean: `@Scheduled` / `@Listener` on a method (Spring `@Scheduled` / `@JmsListener` style), or `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose` for websockets. The legacy method-by-name reflective convention remains as a fallback, so existing handlers keep working unchanged. See the per-decorator pages under `/sdk/` for details.
+Jobs, listeners, and websockets each support exactly **two** declaration styles, and a single `@Component` class uses one or the other - **never both** (the engine rejects a class that mixes them):
+
+1. **Self-describing interface.** Implement the SDK companion interface (`JobHandler`, `MessageHandler`, `WebsocketHandler`) on a `@Component`. The interface carries the binding itself - `cron()`, `destination()` / `kind()`, `endpoint()` - so **no class-level `@Scheduled` / `@Listener` / `@Websocket`** is used. This mirrors Spring's `org.quartz.Job`, `jakarta.jms.MessageListener`, and `TextWebSocketHandler`. You get compile-time signature checking, IDE autocomplete, and default no-op callbacks.
+2. **Method-level annotation.** Annotate a **method** of a `@Component` bean: `@Scheduled` / `@Listener` on a method (Spring `@Scheduled` / `@JmsListener` style). Websockets are the asymmetric case - `@Websocket(endpoint = "…")` stays a **class** annotation (the endpoint has no method-level home, like Jakarta's `@ServerEndpoint`) and the callbacks are bound by `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose`.
+
+Both styles dispatch directly; there is no reflective by-name fallback. See the per-decorator pages under `/sdk/` for details.
 
 On the TypeScript side, dedicated synchronizers (`ComponentSynchronizer`, `EntitySynchronizer`, `OpenAPISynchronizer`, plus the listener / job / websocket / extension synchronizers) scan files matching `*Component.ts`, `*Entity.ts`, `*Controller.ts`, etc. and do the same registration work.
 

--- a/docs/help/develop/decorators-model.md
+++ b/docs/help/develop/decorators-model.md
@@ -24,15 +24,15 @@ Dirigible's modern development model is **decorator-driven on TypeScript** and *
 | Scheduled job | `@Scheduled(...)` | `@Component` implementing `JobHandler` (self-describing `cron()`), or `@Scheduled` on a method of a `@Component` |
 | Message listener | `@Listener(...)` | `@Component` implementing `MessageHandler` (self-describing `destination()`/`kind()`), or `@Listener` on a method of a `@Component` |
 | Websocket | `@Websocket(...)` | `@Component` implementing `WebsocketHandler` (self-describing `endpoint()`), or a `@Websocket` class with `@OnOpen`/`@OnMessage`/`@OnError`/`@OnClose` methods |
-| Extension point | `@ExtensionPoint("description")` on an interface | `@ExtensionPoint("description")` on an interface |
-| Extension provider | `@Extension({target: Contract})` | `@Extension(target=Contract.class, name="...")` |
+| Extension point | `@ExtensionPoint("description")` on an interface | a plain interface (no annotation) |
+| Extension provider | `@Extension({target: Contract})` | a `@Component` implementing the interface |
 | Role check | `@Roles(["admin"])` | `@Roles({"admin"})` |
 
 ## How the wiring happens
 
 The mechanism behind each declaration is the same: at class-load time the platform reflects over the annotations and registers the class with the relevant platform service.
 
-On the Java side a single `ComponentContainer` builds all beans per `ClientClassLoader` generation. Because `@Repository`, `@Controller`, `@Scheduled`, `@Listener`, `@Websocket`, and `@Extension` are all meta-annotated `@Component`, they are beans too - the container instantiates them, satisfies constructor / field / collection injection by type, and then registers each with its service (`@Entity` → `JavaEntityManager`, `@Controller` routes → `ControllerRouter`, and so on). Injection is order-independent: any bean can depend on any other regardless of declaration order, so `@Inject CountryRepository` (or a `CountryRepository` constructor parameter) always resolves within the same rebuild cycle.
+On the Java side every bean is built once per generation. `@Repository`, `@Controller`, and `@Websocket` are `@Component`s, so they are beans too; the platform instantiates them, satisfies constructor / field / collection injection by type, and registers each with its service. Injection is order-independent: any bean can depend on any other regardless of declaration order, so `@Inject CountryRepository` (or a `CountryRepository` constructor parameter) always resolves.
 
 ### Two handler styles - never mixed
 
@@ -52,7 +52,7 @@ On the TypeScript side, dedicated synchronizers (`ComponentSynchronizer`, `Entit
 - [Dependency injection](/help/develop/dependency-injection) - `@Component`, `@Inject`, constructor and collection injection, `@Repository`.
 - [Scheduled jobs](/help/develop/scheduled-jobs) - `@Scheduled`.
 - [Message listeners](/help/develop/message-listeners) - `@Listener`.
-- [Extension providers](/help/develop/extension-providers) - `@Extension`.
+- [Extension providers](/help/develop/extension-providers) - interface + `@Component`, collection injection.
 - [Websockets](/help/develop/websockets) - `@Websocket`.
 - [Security and roles](/help/develop/security-and-roles) - `@Roles`.
 

--- a/docs/help/develop/decorators-model.md
+++ b/docs/help/develop/decorators-model.md
@@ -18,31 +18,25 @@ Dirigible's modern development model is **decorator-driven on TypeScript** and *
 | Primary key | `@Id` + `@Generated("sequence")` | `@Id` + `@GeneratedValue(strategy = GenerationType.SEQUENCE)` |
 | Column | `@Column({name, type})` | `@Column(name=..., length=..., nullable=...)` |
 | Audit fields | `@CreatedAt`, `@UpdatedAt`, `@CreatedBy`, `@UpdatedBy` | `@CreatedAt`, `@UpdatedAt`, `@CreatedBy`, `@UpdatedBy` |
-| Repository / DI | `@Component("CountryRepository")` | `@Repository` |
-| Inject | `@Inject("CountryRepository")` | `@Inject` |
-| Scheduled job | `@Scheduled(...)` | `@Scheduled(expression="0 0 * * * ?")` + optional `implements JobHandler` |
-| Message listener | `@Listener(...)` | `@Listener(name="queue.x", kind=ListenerKind.QUEUE)` + optional `implements MessageHandler` |
-| Websocket | `@Websocket(...)` | `@Websocket(name="chat", endpoint="chat")` + optional `implements WebsocketHandler` |
+| Managed bean | `@Component("Name")` | `@Component` (optional name) |
+| Repository / DI | `@Component("CountryRepository")` | `@Repository` (a `@Component`) |
+| Inject | `@Inject("CountryRepository")` | `@Inject` (field / constructor / parameter) or constructor injection |
+| Scheduled job | `@Scheduled(...)` | `@Scheduled` on a class implementing `JobHandler`, or on a method of a `@Component` |
+| Message listener | `@Listener(...)` | `@Listener` on a class implementing `MessageHandler`, or on a method of a `@Component` |
+| Websocket | `@Websocket(...)` | `@Websocket` on a class implementing `WebsocketHandler`, or `@OnOpen`/`@OnMessage`/`@OnError`/`@OnClose` methods of a `@Component` |
 | Extension point | `@ExtensionPoint("description")` on an interface | `@ExtensionPoint("description")` on an interface |
 | Extension provider | `@Extension({target: Contract})` | `@Extension(target=Contract.class, name="...")` |
 | Role check | `@Roles(["admin"])` | `@Roles({"admin"})` |
 
 ## How the wiring happens
 
-The mechanism behind each declaration is the same: at class-load time a consumer reflects over the annotations and registers the class with the relevant platform service.
+The mechanism behind each declaration is the same: at class-load time the platform reflects over the annotations and registers the class with the relevant platform service.
 
-On the Java side this is the `JavaClassConsumer` SPI run in fixed `@Order`:
+On the Java side a single `ComponentContainer` builds all beans per `ClientClassLoader` generation. Because `@Repository`, `@Controller`, `@Scheduled`, `@Listener`, `@Websocket`, and `@Extension` are all meta-annotated `@Component`, they are beans too - the container instantiates them, satisfies constructor / field / collection injection by type, and then registers each with its service (`@Entity` → `JavaEntityManager`, `@Controller` routes → `ControllerRouter`, and so on). Injection is order-independent: any bean can depend on any other regardless of declaration order, so `@Inject CountryRepository` (or a `CountryRepository` constructor parameter) always resolves within the same rebuild cycle.
 
-1. `EntityClassConsumer` (`@Order(100)`) - `@Entity` classes register with `JavaEntityManager`.
-2. `RepositoryClassConsumer` (`@Order(200)`) - `@Repository` classes are instantiated and stored in `RepositoryRegistry`.
-3. `ControllerClassConsumer` (`@Order(300)`) - `@Controller` classes have their `@Inject` fields resolved, then their routes registered with `ControllerRouter`.
-4. `HandlerClassConsumer` - claims `implements JavaHandler`.
+### Strong interfaces or method-level annotations
 
-The ordering guarantees that `@Inject CountryRepository` resolves inside the controller consumer - the repository has already been registered in the same rebuild cycle.
-
-### Optional typed contracts
-
-`@Scheduled`, `@Listener`, and `@Websocket` each ship a companion interface in the SDK (`JobHandler`, `MessageHandler`, `WebsocketHandler`). Implementing the interface is opt-in - the runtime falls back to method-by-name reflection when the interface is absent, so existing handlers keep working unchanged. The typed path gives compile-time signature checking, IDE autocomplete and refactoring, default no-op methods for callbacks you don't override (`WebsocketHandler`, `MessageHandler.onError`), and direct (non-reflective) dispatch. See the per-decorator pages under `/sdk/` for details.
+`@Scheduled`, `@Listener`, and `@Websocket` each ship a companion interface in the SDK (`JobHandler`, `MessageHandler`, `WebsocketHandler`) - implement it for compile-time signature checking, IDE autocomplete, default no-op callbacks, and direct (non-reflective) dispatch. Alternatively, annotate a **method** of a `@Component` bean: `@Scheduled` / `@Listener` on a method (Spring `@Scheduled` / `@JmsListener` style), or `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose` for websockets. The legacy method-by-name reflective convention remains as a fallback, so existing handlers keep working unchanged. See the per-decorator pages under `/sdk/` for details.
 
 On the TypeScript side, dedicated synchronizers (`ComponentSynchronizer`, `EntitySynchronizer`, `OpenAPISynchronizer`, plus the listener / job / websocket / extension synchronizers) scan files matching `*Component.ts`, `*Entity.ts`, `*Controller.ts`, etc. and do the same registration work.
 
@@ -50,7 +44,7 @@ On the TypeScript side, dedicated synchronizers (`ComponentSynchronizer`, `Entit
 
 - [REST APIs](/help/develop/rest-apis) - `@Controller`, the method verbs, parameter binding, return-value writing.
 - [Entities and persistence](/help/develop/entities-and-persistence) - `@Entity`, `@Id`, `@Column`, audit fields, repository pattern.
-- [Dependency injection](/help/develop/dependency-injection) - `@Inject`, `@Repository`, `@Component`.
+- [Dependency injection](/help/develop/dependency-injection) - `@Component`, `@Inject`, constructor and collection injection, `@Repository`.
 - [Scheduled jobs](/help/develop/scheduled-jobs) - `@Scheduled`.
 - [Message listeners](/help/develop/message-listeners) - `@Listener`.
 - [Extension providers](/help/develop/extension-providers) - `@Extension`.

--- a/docs/help/develop/dependency-injection.md
+++ b/docs/help/develop/dependency-injection.md
@@ -24,7 +24,7 @@ public class GreetingService {
 }
 ```
 
-`@Repository`, `@Controller`, `@Extension`, `@Scheduled`, `@Listener`, and `@Websocket` are all **meta-annotated** with `@Component`, so every one of them is a bean and participates in injection without any extra annotation.
+`@Repository`, `@Controller`, and `@Websocket` are beans in their own right - you do not add `@Component` to them; they already participate in injection.
 
 ### Constructor injection (preferred)
 
@@ -105,7 +105,11 @@ For entity CRUD the recommended pattern stays `@Repository extends JavaRepositor
 
 ### How it is wired
 
-A single `ComponentContainer` builds all beans per `ClientClassLoader` generation. On each rebuild it discovers the `@Component`-annotated classes (including the meta-annotated `@Repository` / `@Controller` / `@Scheduled` / …), instantiates them, and satisfies constructor, field, and collection injection points by type - so any bean can depend on any other regardless of declaration order. A fresh container is built for every generation; the previous one is discarded with its classloader.
+You only declare the dependencies; the platform wires them. The guarantees you can rely on:
+
+- Beans are **singletons** within the application.
+- Every injection point - constructor parameter, `@Inject` field, or collection - is resolved **by type**, so a bean can depend on any other **regardless of declaration order**.
+- Beans are **rebuilt automatically when you change client code** (hot reload); `@PostConstruct` runs once a bean is fully wired and `@PreDestroy` before the previous version is replaced.
 
 ### Example
 

--- a/docs/help/develop/dependency-injection.md
+++ b/docs/help/develop/dependency-injection.md
@@ -1,6 +1,6 @@
 ---
 title: Dependency injection
-description: "@Inject + @Repository on Java, @Component on TypeScript."
+description: "@Component + @Inject on Java, @Component on TypeScript."
 ---
 
 # Dependency injection
@@ -9,53 +9,39 @@ Client code does not participate in Spring's component scan - it is loaded by `C
 
 ## Java
 
-Two annotations and one SPI:
+The Java side is a Spring-style container over your client classes.
 
-- `@Repository` (`org.eclipse.dirigible.sdk.component.Repository`) - marks a class as a singleton candidate. `RepositoryClassConsumer` instantiates it via the public no-arg constructor and stores it in `RepositoryRegistry`.
-- `@Inject` (`org.eclipse.dirigible.sdk.component.Inject`) - field-level injection request. Resolved at class-load time via the `DependencyResolver` SPI chain; `RepositoryRegistry` is the primary resolver.
+### `@Component` - the bean marker
 
-### Resolution order (one rebuild cycle)
-
-`JavaClassConsumer` implementations run in fixed Spring `@Order`:
-
-1. `EntityClassConsumer` (`@Order(100)`).
-2. `RepositoryClassConsumer` (`@Order(200)`).
-3. `ControllerClassConsumer` (`@Order(300)`).
-4. `HandlerClassConsumer` (lowest).
-
-Because the loader drains consumer-outer / class-inner, every `@Repository` is in `RepositoryRegistry` before any `@Controller` is loaded. `@Inject CountryRepository` therefore always resolves.
-
-### Reaching platform beans
-
-The recommended pattern for entity CRUD is `@Repository extends JavaRepository<T>` - that wraps the platform's `JavaEntityStore` and gives you typed `findAll`, `findById`, `save`, `delete`, etc. without touching internal beans:
+`@Component` (`org.eclipse.dirigible.sdk.component.Component`) turns a class into a managed bean. The optional bean name defaults to the decapitalized simple class name (`CountryRepository` → `countryRepository`), following the Spring convention; pass `@Component("name")` to override.
 
 ```java
-import org.eclipse.dirigible.sdk.component.Repository;
-import org.eclipse.dirigible.components.data.store.java.repository.JavaRepository;
+import org.eclipse.dirigible.sdk.component.Component;
 
-@Repository
-public class CountryRepository extends JavaRepository<Country> {
-    public CountryRepository() { super(Country.class); }
+@Component
+public class GreetingService {
+    public String greet(String who) { return "Hello, " + who; }
 }
 ```
 
-For platform beans that have no `JavaRepository` wrapper (logger configuration, custom services), drop down to `BeanProvider.getBean(Class)`:
+`@Repository`, `@Controller`, `@Extension`, `@Scheduled`, `@Listener`, and `@Websocket` are all **meta-annotated** with `@Component`, so every one of them is a bean and participates in injection without any extra annotation.
+
+### Constructor injection (preferred)
+
+Declare the collaborators as constructor parameters. The container resolves each by type when it builds the bean:
 
 ```java
-import org.eclipse.dirigible.components.base.spring.BeanProvider;
-import org.eclipse.dirigible.components.data.store.java.store.JavaEntityStore;
+import org.eclipse.dirigible.sdk.http.Controller;
+import org.eclipse.dirigible.sdk.http.Get;
 
-JavaEntityStore store = BeanProvider.getBean(JavaEntityStore.class);
-```
-
-### Example
-
-```java
 @Controller
 public class CountryController {
 
-    @Inject
-    private CountryRepository countries;
+    private final CountryRepository countries;
+
+    public CountryController(CountryRepository countries) {
+        this.countries = countries;
+    }
 
     @Get("/")
     public List<Country> list() {
@@ -64,7 +50,83 @@ public class CountryController {
 }
 ```
 
-Working sample: [`dirigiblelabs/sample-java-entity-decorators`](https://github.com/dirigiblelabs/sample-java-entity-decorators).
+### Field injection
+
+`@Inject` (`org.eclipse.dirigible.sdk.component.Inject`) is also valid on fields, constructors, and parameters. Field injection is the lighter-weight option when a constructor would be all boilerplate:
+
+```java
+import org.eclipse.dirigible.sdk.component.Inject;
+
+@Controller
+public class CountryController {
+
+    @Inject
+    private CountryRepository countries;
+
+    @Get("/")
+    public List<Country> list() { return countries.findAll(); }
+}
+```
+
+### Collection injection
+
+A `List<T>`, `Set<T>`, or `Collection<T>` parameter or field receives **every** bean assignable to `T`. This is the natural way to consume all implementations of an interface (for example, every provider of an extension point):
+
+```java
+@Component
+public class OrderPipeline {
+
+    private final List<OrderProcessor> processors;
+
+    public OrderPipeline(List<OrderProcessor> processors) {
+        this.processors = processors;
+    }
+}
+```
+
+### Lifecycle callbacks
+
+`@PostConstruct` runs after all dependencies are injected; `@PreDestroy` runs when the bean's generation is torn down on hot-reload.
+
+### Reaching platform beans - the `Beans` facade
+
+To reach platform services from client code, use `Beans` (`org.eclipse.dirigible.sdk.component.Beans`) - the client-facing facade:
+
+```java
+import org.eclipse.dirigible.sdk.component.Beans;
+import org.eclipse.dirigible.components.data.store.java.store.JavaEntityStore;
+
+JavaEntityStore store = Beans.get(JavaEntityStore.class);
+```
+
+`Beans` exposes `get(Class)`, `get(name, Class)`, and `getAll(Class)`. Client code should **not** use the platform-internal `BeanProvider` - `Beans` is the supported entry point.
+
+For entity CRUD the recommended pattern stays `@Repository extends JavaRepository<T>` (typed `findAll`, `findById`, `save`, `delete`, …); inject that repository rather than reaching for `JavaEntityStore` directly.
+
+### How it is wired
+
+A single `ComponentContainer` builds all beans per `ClientClassLoader` generation. On each rebuild it discovers the `@Component`-annotated classes (including the meta-annotated `@Repository` / `@Controller` / `@Scheduled` / …), instantiates them, and satisfies constructor, field, and collection injection points by type - so any bean can depend on any other regardless of declaration order. A fresh container is built for every generation; the previous one is discarded with its classloader.
+
+### Example
+
+```java
+@Controller
+public class CountryController {
+
+    private final CountryRepository countries;
+
+    public CountryController(CountryRepository countries) {
+        this.countries = countries;
+    }
+
+    @Get("/")
+    public List<Country> list() {
+        return countries.findAll();
+    }
+}
+```
+
+Working sample: [`dirigiblelabs/sample-java-entity-decorators`](https://github.com/dirigiblelabs/sample-java-entity-decorators). SDK reference: [`/sdk/`](https://www.dirigible.io/sdk/).
 
 ## TypeScript
 

--- a/docs/help/develop/dependency-injection.md
+++ b/docs/help/develop/dependency-injection.md
@@ -109,24 +109,49 @@ A single `ComponentContainer` builds all beans per `ClientClassLoader` generatio
 
 ### Example
 
+A plain `@Component` service injected into a controller by constructor, with the `Beans` facade as the programmatic-lookup alternative:
+
 ```java
-@Controller
-public class CountryController {
+import org.eclipse.dirigible.sdk.component.Component;
 
-    private final CountryRepository countries;
+@Component
+public class GreetingService {
 
-    public CountryController(CountryRepository countries) {
-        this.countries = countries;
-    }
-
-    @Get("/")
-    public List<Country> list() {
-        return countries.findAll();
+    public String greet(String name) {
+        return "Hello, " + name + "!";
     }
 }
 ```
 
-Working sample: [`dirigiblelabs/sample-java-entity-decorators`](https://github.com/dirigiblelabs/sample-java-entity-decorators). SDK reference: [`/sdk/`](https://www.dirigible.io/sdk/).
+```java
+import org.eclipse.dirigible.sdk.component.Beans;
+import org.eclipse.dirigible.sdk.http.Controller;
+import org.eclipse.dirigible.sdk.http.Get;
+import org.eclipse.dirigible.sdk.http.PathParam;
+
+@Controller
+public class GreetingController {
+
+    private final GreetingService greetings;
+
+    public GreetingController(GreetingService greetings) {
+        this.greetings = greetings;
+    }
+
+    @Get("/greet/{name}")
+    public String greet(@PathParam("name") String name) {
+        return greetings.greet(name);
+    }
+
+    @Get("/greet-via-beans/{name}")
+    public String greetViaBeans(@PathParam("name") String name) {
+        return Beans.get(GreetingService.class)
+                    .greet(name);
+    }
+}
+```
+
+**Sample project:** [`dirigiblelabs/sample-java-entity-decorators`](https://github.com/dirigiblelabs/sample-java-entity-decorators) - `GreetingService` + `GreetingController` (constructor injection and `Beans.get`), and `CountryController` with `@Inject` field injection. SDK reference: [`/sdk/`](https://www.dirigible.io/sdk/).
 
 ## TypeScript
 

--- a/docs/help/develop/entities-and-persistence.md
+++ b/docs/help/develop/entities-and-persistence.md
@@ -92,14 +92,17 @@ public class CountryRepository extends JavaRepository<Country> {
 }
 ```
 
-Controllers `@Inject` the repository and call typed methods directly - no `JavaEntityStore`, no `BeanProvider`:
+Controllers inject the repository - constructor injection is preferred - and call typed methods directly, with no `JavaEntityStore` and no `BeanProvider`:
 
 ```java
 @Controller
 public class CountryController {
 
-    @Inject
-    private CountryRepository countries;
+    private final CountryRepository countries;
+
+    public CountryController(CountryRepository countries) {
+        this.countries = countries;
+    }
 
     @Get("/")        public List<Country> list()                          { return countries.findAll(); }
     @Get("/{id}")    public Country       byId(@PathParam("id") Long id)  { return countries.findById(id); }
@@ -107,6 +110,8 @@ public class CountryController {
     @Delete("/{id}") public void          remove(@PathParam("id") Long id) { countries.deleteById(id); }
 }
 ```
+
+Field `@Inject` on the repository works too; see [Dependency injection](/help/develop/dependency-injection).
 
 Working sample: [`dirigiblelabs/sample-java-entity-decorators`](https://github.com/dirigiblelabs/sample-java-entity-decorators).
 
@@ -131,7 +136,9 @@ Entities are stored in the **default user-data datasource**, which is tenant-iso
 
 ## See also
 
+- Working sample: [`dirigiblelabs/sample-java-entity-decorators`](https://github.com/dirigiblelabs/sample-java-entity-decorators).
 - [Java SDK - db](/sdk/db/).
 - [TypeScript API - db](/api/db/).
+- [SDK reference](https://www.dirigible.io/sdk/).
 - [Dependency injection](/help/develop/dependency-injection).
 - [Working with data](/help/develop/working-with-data).

--- a/docs/help/develop/entities-and-persistence.md
+++ b/docs/help/develop/entities-and-persistence.md
@@ -28,24 +28,9 @@ Both paths end up in the same Hibernate `SessionFactory`, rooted at the default 
 | `@UpdatedBy` | Auto-populated with `UserFacade.getName()` on update. |
 | `@Documentation("...")` | Free-text description; surfaces in OpenAPI. |
 
-## TypeScript and Java side by side
+## Defining an entity
 
-```ts
-import { Entity, Table, Id, Generated, Column } from "@aerokit/sdk/db/decorators";
-
-@Entity("Country")
-@Table("SAMPLE_COUNTRY")
-export class Country {
-
-  @Id()
-  @Generated("sequence")
-  @Column({ name: "COUNTRY_ID", type: "long" })
-  public id?: number;
-
-  @Column({ name: "COUNTRY_NAME", type: "string" })
-  public name?: string;
-}
-```
+### Java
 
 ```java
 package demo;
@@ -81,11 +66,32 @@ public class Country {
 }
 ```
 
+### TypeScript / JavaScript
+
+```ts
+import { Entity, Table, Id, Generated, Column } from "@aerokit/sdk/db/decorators";
+
+@Entity("Country")
+@Table("SAMPLE_COUNTRY")
+export class Country {
+
+  @Id()
+  @Generated("sequence")
+  @Column({ name: "COUNTRY_ID", type: "long" })
+  public id?: number;
+
+  @Column({ name: "COUNTRY_NAME", type: "string" })
+  public name?: string;
+}
+```
+
 ## Repository pattern
 
 The recommended pattern is to subclass `JavaRepository<T>` (Java) or `Repository<T>` (TypeScript). Both deliver typed CRUD plus `findAll`, `findById`, `save`, `update`, `delete`, `deleteById`, `count`, and `query`/HQL out of the box.
 
-**Java** - `@Repository` registers the class as a singleton; `JavaRepository<T>` is the typed CRUD base:
+### Java
+
+`@Repository` registers the class as a singleton; `JavaRepository<T>` is the typed CRUD base:
 
 ```java
 import org.eclipse.dirigible.sdk.component.Repository;
@@ -119,11 +125,11 @@ public class CountryController {
 }
 ```
 
-Field `@Inject` on the repository works too; see [Dependency injection](/help/develop/dependency-injection).
+Field `@Inject` on the repository works too; see [Dependency injection](/help/develop/dependency-injection). Working sample: [`dirigiblelabs/sample-java-entity-decorators`](https://github.com/dirigiblelabs/sample-java-entity-decorators).
 
-Working sample: [`dirigiblelabs/sample-java-entity-decorators`](https://github.com/dirigiblelabs/sample-java-entity-decorators).
+### TypeScript / JavaScript
 
-**TypeScript** - `Repository<T>` is auto-generated; subclass it via `@Component`:
+`Repository<T>` is auto-generated; subclass it via `@Component`:
 
 ```ts
 import { Repository } from "@aerokit/sdk/db";

--- a/docs/help/develop/entities-and-persistence.md
+++ b/docs/help/develop/entities-and-persistence.md
@@ -48,28 +48,36 @@ export class Country {
 ```
 
 ```java
-package com.acme.demo;
+package demo;
 
+import org.eclipse.dirigible.sdk.db.Column;
 import org.eclipse.dirigible.sdk.db.Entity;
-import org.eclipse.dirigible.sdk.db.Table;
-import org.eclipse.dirigible.sdk.db.Id;
 import org.eclipse.dirigible.sdk.db.GeneratedValue;
 import org.eclipse.dirigible.sdk.db.GenerationType;
-import org.eclipse.dirigible.sdk.db.Column;
+import org.eclipse.dirigible.sdk.db.Id;
+import org.eclipse.dirigible.sdk.db.Table;
+import org.eclipse.dirigible.sdk.platform.Documentation;
 
 @Entity
 @Table(name = "SAMPLE_COUNTRY")
+@Documentation("Sample Country Entity")
 public class Country {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "COUNTRY_ID")
-    private Long id;
+    @Documentation("Auto-generated primary key")
+    public Long id;
 
-    @Column(name = "COUNTRY_NAME")
-    private String name;
+    @Column(name = "COUNTRY_CODE2", length = 2)
+    public String code2;
 
-    // getters and setters
+    @Column(name = "COUNTRY_CODE3", length = 3)
+    public String code3;
+
+    @Column(name = "COUNTRY_NAME", length = 128)
+    @Documentation("Official short name")
+    public String name;
 }
 ```
 

--- a/docs/help/develop/entities-and-persistence.md
+++ b/docs/help/develop/entities-and-persistence.md
@@ -144,10 +144,6 @@ export class CountryRepository extends Repository<Country> {
 }
 ```
 
-## Tenancy
-
-Entities are stored in the **default user-data datasource**, which is tenant-isolated when `DIRIGIBLE_MULTI_TENANT_MODE` is on. Each tenant has its own physical (or logical) database; the same `@Entity` is reconciled per tenant.
-
 ## See also
 
 - Working sample: [`dirigiblelabs/sample-java-entity-decorators`](https://github.com/dirigiblelabs/sample-java-entity-decorators).

--- a/docs/help/develop/extension-providers.md
+++ b/docs/help/develop/extension-providers.md
@@ -19,9 +19,10 @@ Two coexisting forms:
 ```java
 import org.eclipse.dirigible.sdk.extensions.ExtensionPoint;
 
-@ExtensionPoint("Order processors")
-public interface OrderProcessor {
-    void process(Order order);
+@ExtensionPoint("Sample Java extension point")
+public interface SampleExtensionPoint {
+
+    String describe();
 }
 ```
 
@@ -30,39 +31,42 @@ public interface OrderProcessor {
 ```java
 import org.eclipse.dirigible.sdk.extensions.Extension;
 
-@Extension(target = OrderProcessor.class, name = "fast-processor")
-public class FastOrderProcessor implements OrderProcessor {
+@Extension(target = SampleExtensionPoint.class, name = "sample-contribution")
+public class SampleContribution implements SampleExtensionPoint {
 
     @Override
-    public void process(Order order) {
-        // ...
+    public String describe() {
+        return "Hello from SampleContribution!";
     }
 }
 ```
 
-The runtime validates that `FastOrderProcessor` implements `OrderProcessor` at registration time. Consumers receive instances cast to the interface - no reflection.
+The runtime validates that `SampleContribution` implements `SampleExtensionPoint` at registration time. Consumers receive instances cast to the interface - no reflection.
 
 ### Consume via collection injection (recommended)
 
-Because every `@Extension` provider is a managed bean, the Spring-style way to receive all implementations is to inject a `List<OrderProcessor>` into a `@Controller` or `@Component`. The container populates it with every bean assignable to the interface:
+Because every `@Extension` provider is a managed bean, the Spring-style way to receive all implementations is to inject a `List<SampleExtensionPoint>` into a `@Controller` or `@Component`. The container populates it with every bean assignable to the interface:
 
 ```java
-import org.eclipse.dirigible.sdk.component.Component;
 import java.util.List;
 
-@Component
-public class OrderPipeline {
+import org.eclipse.dirigible.sdk.http.Controller;
+import org.eclipse.dirigible.sdk.http.Get;
 
-    private final List<OrderProcessor> processors;
+@Controller
+public class InjectingConsumer {
 
-    public OrderPipeline(List<OrderProcessor> processors) {
-        this.processors = processors;
+    private final List<SampleExtensionPoint> contributions;
+
+    public InjectingConsumer(List<SampleExtensionPoint> contributions) {
+        this.contributions = contributions;
     }
 
-    public void run(Order order) {
-        for (OrderProcessor p : processors) {
-            p.process(order);
-        }
+    @Get("/injected-contributions")
+    public List<String> list() {
+        return contributions.stream()
+                            .map(SampleExtensionPoint::describe)
+                            .toList();
     }
 }
 ```
@@ -72,17 +76,28 @@ public class OrderPipeline {
 When you cannot inject - or want to look up providers at an arbitrary point - `Extensions.find(Class)` returns them directly:
 
 ```java
-import org.eclipse.dirigible.sdk.extensions.Extensions;
+import java.util.List;
 
-List<OrderProcessor> processors = Extensions.find(OrderProcessor.class);
-for (OrderProcessor p : processors) {
-    p.process(order);
+import org.eclipse.dirigible.sdk.extensions.Extensions;
+import org.eclipse.dirigible.sdk.http.Controller;
+import org.eclipse.dirigible.sdk.http.Get;
+
+@Controller
+public class ExtensionConsumer {
+
+    @Get("/contributions")
+    public List<String> listContributions() {
+        return Extensions.find(SampleExtensionPoint.class)
+                         .stream()
+                         .map(SampleExtensionPoint::describe)
+                         .toList();
+    }
 }
 ```
 
 `Extensions.find` and the string-keyed `Extensions.getExtensions` below also work across runtimes (TypeScript providers, JS/TS module extensions) and remain available for back-compatibility, so prefer them when the consumer must see providers that injection cannot reach.
 
-A complete end-to-end example lives at [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator).
+**Sample project:** [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator) - `SampleExtensionPoint` + `SampleContribution`, consumed both by `ExtensionConsumer` (`Extensions.find`) and `InjectingConsumer` (constructor `List<SampleExtensionPoint>` collection injection). SDK reference: [`/sdk/`](https://www.dirigible.io/sdk/).
 
 ## String-keyed artefacts
 

--- a/docs/help/develop/extension-providers.md
+++ b/docs/help/develop/extension-providers.md
@@ -119,7 +119,7 @@ for (const m of modules) {
 }
 ```
 
-**Sample project:** [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator) (branch `feat/spring-style-extension-injection`) - `SampleExtensionPoint` (plain interface) + `SampleContribution` (`@Component("sample-contribution")`), consumed both by `InjectingConsumer` (constructor `List<SampleExtensionPoint>` collection injection) and `ExtensionConsumer` (`Extensions.find`). SDK reference: [`/sdk/`](https://www.dirigible.io/sdk/).
+**Sample project:** [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator) - `SampleExtensionPoint` (plain interface) + `SampleContribution` (`@Component("sample-contribution")`), consumed both by `InjectingConsumer` (constructor `List<SampleExtensionPoint>` collection injection) and `ExtensionConsumer` (`Extensions.find`). SDK reference: [`/sdk/`](https://www.dirigible.io/sdk/).
 
 ## String-keyed artefacts
 
@@ -166,7 +166,7 @@ For typed wiring within a single project, prefer [dependency injection](/help/de
 
 ## See also
 
-- Working sample: [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator) (branch `feat/spring-style-extension-injection`).
+- Working sample: [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator).
 - [SDK reference](https://www.dirigible.io/sdk/).
 - [`Extensions`](/sdk/extensions/extensions)
 - [Extension point artefact](/help/artefacts/extensibility/extensionpoint)

--- a/docs/help/develop/extension-providers.md
+++ b/docs/help/develop/extension-providers.md
@@ -42,7 +42,34 @@ public class FastOrderProcessor implements OrderProcessor {
 
 The runtime validates that `FastOrderProcessor` implements `OrderProcessor` at registration time. Consumers receive instances cast to the interface - no reflection.
 
-### Discover and invoke
+### Consume via collection injection (recommended)
+
+Because every `@Extension` provider is a managed bean, the Spring-style way to receive all implementations is to inject a `List<OrderProcessor>` into a `@Controller` or `@Component`. The container populates it with every bean assignable to the interface:
+
+```java
+import org.eclipse.dirigible.sdk.component.Component;
+import java.util.List;
+
+@Component
+public class OrderPipeline {
+
+    private final List<OrderProcessor> processors;
+
+    public OrderPipeline(List<OrderProcessor> processors) {
+        this.processors = processors;
+    }
+
+    public void run(Order order) {
+        for (OrderProcessor p : processors) {
+            p.process(order);
+        }
+    }
+}
+```
+
+### Discover programmatically
+
+When you cannot inject - or want to look up providers at an arbitrary point - `Extensions.find(Class)` returns them directly:
 
 ```java
 import org.eclipse.dirigible.sdk.extensions.Extensions;
@@ -52,6 +79,8 @@ for (OrderProcessor p : processors) {
     p.process(order);
 }
 ```
+
+`Extensions.find` and the string-keyed `Extensions.getExtensions` below also work across runtimes (TypeScript providers, JS/TS module extensions) and remain available for back-compatibility, so prefer them when the consumer must see providers that injection cannot reach.
 
 A complete end-to-end example lives at [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator).
 
@@ -106,6 +135,8 @@ For typed wiring within a single project, prefer [dependency injection](/help/de
 
 ## See also
 
+- Working sample: [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator).
+- [SDK reference](https://www.dirigible.io/sdk/).
 - [`@ExtensionPoint` / `@Extension`](/sdk/extensions/decorators)
 - [`Extensions`](/sdk/extensions/extensions)
 - [Extension point artefact](/help/artefacts/extensibility/extensionpoint)

--- a/docs/help/develop/extension-providers.md
+++ b/docs/help/develop/extension-providers.md
@@ -9,17 +9,18 @@ The extensions mechanism lets one piece of code declare a pluggable contract and
 
 Two coexisting forms:
 
-- **Typed Java** - an interface marked with `@ExtensionPoint` defines the contract; classes marked with `@Extension(target = ContractInterface.class)` plug in. Discovered with `Extensions.find(Class)`. Preferred for Java code.
-- **String-keyed artefacts** - `*.extensionpoint` declares a named point; `*.extension` registers a JS / TS / Java module against the named point. Discovered with `Extensions.getExtensions(String)`. Used by older code and by TypeScript-side extensions.
+- **Typed Java** - an **extension point is a plain Java interface**; a **contribution is a `@Component` bean that implements it**. Consumers receive all contributions via collection injection (`List<SampleExtensionPoint>`) or `Extensions.find(Class)`. Preferred for Java code.
+- **String-keyed artefacts** - `*.extensionpoint` declares a named point; `*.extension` registers a JS / TS module against the named point. Discovered with `Extensions.getExtensions(String)`. Used by TypeScript-side extensions and by older code.
 
 ## Typed Java extensions
 
 ### Declare the contract
 
-```java
-import org.eclipse.dirigible.sdk.extensions.ExtensionPoint;
+An extension point is just a plain Java interface - no annotation:
 
-@ExtensionPoint("Sample Java extension point")
+```java
+package demo.extension;
+
 public interface SampleExtensionPoint {
 
     String describe();
@@ -28,10 +29,14 @@ public interface SampleExtensionPoint {
 
 ### Contribute an implementation
 
-```java
-import org.eclipse.dirigible.sdk.extensions.Extension;
+A contribution is a `@Component` bean that implements the interface - no extra annotation. The contribution's name is its `@Component` name:
 
-@Extension(target = SampleExtensionPoint.class, name = "sample-contribution")
+```java
+package demo.extension;
+
+import org.eclipse.dirigible.sdk.component.Component;
+
+@Component("sample-contribution")
 public class SampleContribution implements SampleExtensionPoint {
 
     @Override
@@ -41,13 +46,17 @@ public class SampleContribution implements SampleExtensionPoint {
 }
 ```
 
-The runtime validates that `SampleContribution` implements `SampleExtensionPoint` at registration time. Consumers receive instances cast to the interface - no reflection.
+Consumers receive instances typed as the interface - no reflection, no `Map` payloads.
 
-### Consume via collection injection (recommended)
+### Consume at runtime
 
-Because every `@Extension` provider is a managed bean, the Spring-style way to receive all implementations is to inject a `List<SampleExtensionPoint>` into a `@Controller` or `@Component`. The container populates it with every bean assignable to the interface:
+#### Java
+
+**Collection injection (preferred).** Because every contribution is a `@Component`, the Spring-style way to receive all implementations is to inject a `List<SampleExtensionPoint>` through the constructor of a `@Controller` or `@Component`. The container populates it with every bean assignable to the interface:
 
 ```java
+package demo.extension;
+
 import java.util.List;
 
 import org.eclipse.dirigible.sdk.http.Controller;
@@ -71,11 +80,11 @@ public class InjectingConsumer {
 }
 ```
 
-### Discover programmatically
-
-When you cannot inject - or want to look up providers at an arbitrary point - `Extensions.find(Class)` returns them directly:
+**`Extensions.find(Class)` (programmatic alternative).** When you cannot inject - or want to look up providers at an arbitrary point - `Extensions.find(Class)` returns them directly:
 
 ```java
+package demo.extension;
+
 import java.util.List;
 
 import org.eclipse.dirigible.sdk.extensions.Extensions;
@@ -86,7 +95,7 @@ import org.eclipse.dirigible.sdk.http.Get;
 public class ExtensionConsumer {
 
     @Get("/contributions")
-    public List<String> listContributions() {
+    public List<String> listContributions() throws Exception {
         return Extensions.find(SampleExtensionPoint.class)
                          .stream()
                          .map(SampleExtensionPoint::describe)
@@ -95,9 +104,22 @@ public class ExtensionConsumer {
 }
 ```
 
-`Extensions.find` and the string-keyed `Extensions.getExtensions` below also work across runtimes (TypeScript providers, JS/TS module extensions) and remain available for back-compatibility, so prefer them when the consumer must see providers that injection cannot reach.
+`Extensions.find` also works across runtimes and remains available for back-compatibility, so prefer it when the consumer must see providers that injection cannot reach.
 
-**Sample project:** [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator) - `SampleExtensionPoint` + `SampleContribution`, consumed both by `ExtensionConsumer` (`Extensions.find`) and `InjectingConsumer` (constructor `List<SampleExtensionPoint>` collection injection). SDK reference: [`/sdk/`](https://www.dirigible.io/sdk/).
+#### TypeScript / JavaScript
+
+TypeScript-side extensions use the string-keyed artefacts described below; `Extensions.getExtensions(String)` returns the registry paths of the contributing modules:
+
+```ts
+import { Extensions } from "@aerokit/sdk/extensions";
+
+const modules = Extensions.getExtensions("my-app-menu-items");
+for (const m of modules) {
+    // m is the registry path of a contributing module; load and invoke as appropriate
+}
+```
+
+**Sample project:** [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator) (branch `feat/spring-style-extension-injection`) - `SampleExtensionPoint` (plain interface) + `SampleContribution` (`@Component("sample-contribution")`), consumed both by `InjectingConsumer` (constructor `List<SampleExtensionPoint>` collection injection) and `ExtensionConsumer` (`Extensions.find`). SDK reference: [`/sdk/`](https://www.dirigible.io/sdk/).
 
 ## String-keyed artefacts
 
@@ -134,12 +156,6 @@ for (const m of modules) {
 }
 ```
 
-```java
-import org.eclipse.dirigible.sdk.extensions.Extensions;
-
-String[] modules = Extensions.getExtensions("my-app-menu-items");
-```
-
 ## When to use this
 
 - IDE chrome - pluggable menu items, perspectives, views.
@@ -150,9 +166,8 @@ For typed wiring within a single project, prefer [dependency injection](/help/de
 
 ## See also
 
-- Working sample: [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator).
+- Working sample: [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator) (branch `feat/spring-style-extension-injection`).
 - [SDK reference](https://www.dirigible.io/sdk/).
-- [`@ExtensionPoint` / `@Extension`](/sdk/extensions/decorators)
 - [`Extensions`](/sdk/extensions/extensions)
 - [Extension point artefact](/help/artefacts/extensibility/extensionpoint)
 - [Extension artefact](/help/artefacts/extensibility/extension)

--- a/docs/help/develop/index.md
+++ b/docs/help/develop/index.md
@@ -23,7 +23,7 @@ Dirigible's modern development model is **decorator / annotation driven**: you d
 - **[Dependency injection](/help/develop/dependency-injection)** - `@Inject` + `@Repository` + `@Component`.
 - **[Scheduled jobs](/help/develop/scheduled-jobs)** - `@Scheduled`.
 - **[Message listeners](/help/develop/message-listeners)** - `@Listener` + `ListenerKind`.
-- **[Extension providers](/help/develop/extension-providers)** - `@Extension`.
+- **[Extension providers](/help/develop/extension-providers)** - interface + `@Component`, collection injection.
 - **[Websockets](/help/develop/websockets)** - `@Websocket`.
 - **[Security and roles](/help/develop/security-and-roles)** - `@Roles` + `UserFacade`.
 

--- a/docs/help/develop/index.md
+++ b/docs/help/develop/index.md
@@ -16,6 +16,7 @@ Dirigible's modern development model is **decorator / annotation driven**: you d
 
 ## Application building blocks
 
+- **[Coming from Spring Boot](/help/develop/coming-from-spring-boot)** - a fast-start map for Spring developers.
 - **[The decorator / annotation model](/help/develop/decorators-model)**
 - **[REST APIs](/help/develop/rest-apis)** - `@Controller` + `@Get` / `@Post` + `@Body` etc.
 - **[Entities and persistence](/help/develop/entities-and-persistence)** - `@Entity`, `JavaEntityStore`.

--- a/docs/help/develop/languages/java.md
+++ b/docs/help/develop/languages/java.md
@@ -48,14 +48,17 @@ Save as `/registry/public/demo/com/acme/demo/HelloController.java`. The next syn
 
 ## Dependency injection
 
-`@Inject` resolves against the chain of `DependencyResolver` SPIs - `RepositoryRegistry` (built from `@Repository`-annotated classes) is the primary one. The fan-out order inside one rebuild cycle is `@Entity` → `@Repository` → `@Controller`, so `@Inject CountryRepository` is guaranteed to resolve when the controller is loaded.
+`@Component` makes a class a managed bean - and `@Repository`, `@Controller`, `@Scheduled`, `@Listener`, `@Websocket`, and `@Extension` are all `@Component`s. A single `ComponentContainer` builds every bean per `ClientClassLoader` generation and satisfies constructor, field (`@Inject`), and collection (`List<T>`) injection by type, independent of declaration order - so `CountryRepository` resolves whether you inject it in the constructor or via a field. Constructor injection is preferred.
 
 ```java
 @Controller("/countries")
 public class CountryController {
 
-    @Inject
-    private CountryRepository repository;
+    private final CountryRepository repository;
+
+    public CountryController(CountryRepository repository) {
+        this.repository = repository;
+    }
 
     @Get
     public List<Country> findAll() {
@@ -64,14 +67,16 @@ public class CountryController {
 }
 ```
 
-Client classes are loaded by `ClientClassLoader`, not Spring-scanned, so `@Autowired` is a no-op. For platform beans that have no `@Repository` wrapper, use `BeanProvider.getBean(SomeBean.class)`:
+Client classes are loaded by `ClientClassLoader`, not Spring-scanned, so `@Autowired` is a no-op. To reach platform beans from client code, use the `Beans` facade - `Beans.get(Class)`, `Beans.get(name, Class)`, `Beans.getAll(Class)` - rather than the platform-internal `BeanProvider`:
 
 ```java
-import org.eclipse.dirigible.components.spring.BeanProvider;
-import org.eclipse.dirigible.components.data.store.JavaEntityStore;
+import org.eclipse.dirigible.sdk.component.Beans;
+import org.eclipse.dirigible.components.data.store.java.store.JavaEntityStore;
 
-JavaEntityStore store = BeanProvider.getBean(JavaEntityStore.class);
+JavaEntityStore store = Beans.get(JavaEntityStore.class);
 ```
+
+See [Dependency injection](/help/develop/dependency-injection) for the full model.
 
 ## See also
 

--- a/docs/help/develop/languages/java.md
+++ b/docs/help/develop/languages/java.md
@@ -48,7 +48,7 @@ Save as `/registry/public/demo/com/acme/demo/HelloController.java`. The next syn
 
 ## Dependency injection
 
-`@Component` makes a class a managed bean - and `@Repository`, `@Controller`, `@Scheduled`, `@Listener`, `@Websocket`, and `@Extension` are all `@Component`s. A single `ComponentContainer` builds every bean per `ClientClassLoader` generation and satisfies constructor, field (`@Inject`), and collection (`List<T>`) injection by type, independent of declaration order - so `CountryRepository` resolves whether you inject it in the constructor or via a field. Constructor injection is preferred.
+`@Component` makes a class a managed bean - and `@Repository`, `@Controller`, and `@Websocket` are `@Component`s too. Every bean is built once per generation, with constructor, field (`@Inject`), and collection (`List<T>`) injection satisfied by type, independent of declaration order - so `CountryRepository` resolves whether you inject it in the constructor or via a field. Constructor injection is preferred.
 
 ```java
 @Controller("/countries")

--- a/docs/help/develop/message-listeners.md
+++ b/docs/help/develop/message-listeners.md
@@ -11,7 +11,9 @@ description: JMS-style listeners over the embedded ActiveMQ broker.
 
 A class with an `onMessage(String)` method, annotated with the queue or topic name and the kind.
 
-**Java:**
+**Java** - two equivalent styles.
+
+Strong interface - a class annotated `@Listener` that implements `MessageHandler`:
 
 ```java
 package com.acme.demo;
@@ -30,7 +32,26 @@ public class OrderListener implements MessageHandler {
 }
 ```
 
-`MessageHandler` is the optional typed contract for the listener callbacks - `onMessage(String)` plus a `default onError(String) {}`. Implementing it gives compile-time signature checking and a direct dispatch path; classes that don't implement it keep working via reflective `onMessage` / `onError` lookup. See [`/sdk/messaging/decorators`](/sdk/messaging/decorators) for details.
+Method-level - `@Listener` on a method of a `@Component` bean (Spring `@JmsListener` style), so a single bean can hold several listeners and inject collaborators:
+
+```java
+package com.acme.demo;
+
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.messaging.Listener;
+import org.eclipse.dirigible.sdk.messaging.ListenerKind;
+
+@Component
+public class OrderListeners {
+
+    @Listener(name = "queue.orders", kind = ListenerKind.QUEUE)
+    public void onOrder(String body) {
+        // handle message
+    }
+}
+```
+
+`MessageHandler` is the optional typed contract for the listener callbacks - `onMessage(String)` plus a `default onError(String) {}`. Implementing it (or using the method-level annotation) gives compile-time signature checking and a direct dispatch path; otherwise the runtime falls back to reflective `onMessage` / `onError` lookup. See [`/sdk/messaging/decorators`](/sdk/messaging/decorators) for details.
 
 **TypeScript:**
 
@@ -83,6 +104,8 @@ Listeners are **tenant-isolated** - each tenant gets its own consumer for the sa
 
 ## See also
 
+- Working sample: [`dirigiblelabs/sample-java-listener-decorator`](https://github.com/dirigiblelabs/sample-java-listener-decorator).
 - [TypeScript API - messaging](/api/).
 - [Java SDK - messaging](/sdk/).
+- [SDK reference](https://www.dirigible.io/sdk/).
 - Messaging perspective.

--- a/docs/help/develop/message-listeners.md
+++ b/docs/help/develop/message-listeners.md
@@ -7,23 +7,33 @@ description: JMS-style listeners over the embedded ActiveMQ broker.
 
 `engine-listeners` runs message-bus listeners against the embedded ActiveMQ broker. Two declaration styles are supported.
 
-## `@Listener` annotation
+## `@Component` listener
 
-A class with an `onMessage(String)` method, annotated with the queue or topic name and the kind.
+A listener is a `@Component` bean. There are exactly **two** styles. A class uses **one or the other, never both** - the engine rejects a class that mixes them.
 
-**Java** - two equivalent styles.
+**Java**
 
-Strong interface - a class annotated `@Listener` that implements `MessageHandler`:
+**Style 1 - self-describing interface.** A `@Component` that implements `MessageHandler`. The interface carries the binding itself: `destination()` names the queue or topic, `kind()` (a `default`, `QUEUE`) selects the semantics, and `onMessage(String)` handles the message (plus a `default onError(String)`), so **no class-level `@Listener`** is used. This mirrors `jakarta.jms.MessageListener`.
 
 ```java
 package com.acme.demo;
 
-import org.eclipse.dirigible.sdk.messaging.Listener;
+import org.eclipse.dirigible.sdk.component.Component;
 import org.eclipse.dirigible.sdk.messaging.ListenerKind;
 import org.eclipse.dirigible.sdk.messaging.MessageHandler;
 
-@Listener(name = "queue.orders", kind = ListenerKind.QUEUE)
+@Component
 public class OrderListener implements MessageHandler {
+
+    @Override
+    public String destination() {
+        return "queue.orders";
+    }
+
+    @Override
+    public ListenerKind kind() {
+        return ListenerKind.QUEUE;
+    }
 
     @Override
     public void onMessage(String body) {
@@ -32,7 +42,7 @@ public class OrderListener implements MessageHandler {
 }
 ```
 
-Method-level - `@Listener` on a method of a `@Component` bean (Spring `@JmsListener` style), so a single bean can hold several listeners and inject collaborators:
+**Style 2 - method-level `@Listener`.** `@Listener(name = "…", kind = …)` on a public `void m(String)` method of a `@Component` (Spring `@JmsListener` style), so a single bean can hold several listeners and inject collaborators:
 
 ```java
 package com.acme.demo;
@@ -51,7 +61,7 @@ public class OrderListeners {
 }
 ```
 
-`MessageHandler` is the optional typed contract for the listener callbacks - `onMessage(String)` plus a `default onError(String) {}`. Implementing it (or using the method-level annotation) gives compile-time signature checking and a direct dispatch path; otherwise the runtime falls back to reflective `onMessage` / `onError` lookup. See [`/sdk/messaging/decorators`](/sdk/messaging/decorators) for details.
+Both styles give compile-time signature checking and a direct dispatch path. There is no reflective by-name fallback. See [`/sdk/messaging/decorators`](/sdk/messaging/decorators) for details.
 
 **TypeScript:**
 

--- a/docs/help/develop/message-listeners.md
+++ b/docs/help/develop/message-listeners.md
@@ -16,52 +16,65 @@ A listener is a `@Component` bean. There are exactly **two** styles. A class use
 **Style 1 - self-describing interface.** A `@Component` that implements `MessageHandler`. The interface carries the binding itself: `destination()` names the queue or topic, `kind()` (a `default`, `QUEUE`) selects the semantics, and `onMessage(String)` handles the message (plus a `default onError(String)`), so **no class-level `@Listener`** is used. This mirrors `jakarta.jms.MessageListener`.
 
 ```java
-package com.acme.demo;
+package demo.listener;
 
 import org.eclipse.dirigible.sdk.component.Component;
-import org.eclipse.dirigible.sdk.messaging.ListenerKind;
 import org.eclipse.dirigible.sdk.messaging.MessageHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component
 public class OrderListener implements MessageHandler {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger("app.out");
+
     @Override
     public String destination() {
-        return "queue.orders";
+        return "java-order-queue";
     }
 
     @Override
-    public ListenerKind kind() {
-        return ListenerKind.QUEUE;
+    public void onMessage(String message) {
+        LOGGER.info("OrderListener received: {}", message);
     }
 
     @Override
-    public void onMessage(String body) {
-        // handle message
+    public void onError(String error) {
+        LOGGER.error("OrderListener error: {}", error);
     }
 }
 ```
 
-**Style 2 - method-level `@Listener`.** `@Listener(name = "…", kind = …)` on a public `void m(String)` method of a `@Component` (Spring `@JmsListener` style), so a single bean can hold several listeners and inject collaborators:
+`kind()` defaults to `QUEUE`, so a queue listener overrides only `destination()` and `onMessage` (and optionally `onError`).
+
+**Style 2 - method-level `@Listener`.** `@Listener(name = "…", kind = …)` on a public `void m(String)` method of a `@Component` (Spring `@JmsListener` style), so a single bean can hold several listeners and inject collaborators. Here the listener depends on a plain `@Component` collaborator (`Auditor`) injected through the constructor:
 
 ```java
-package com.acme.demo;
+package demo.listener;
 
 import org.eclipse.dirigible.sdk.component.Component;
 import org.eclipse.dirigible.sdk.messaging.Listener;
 import org.eclipse.dirigible.sdk.messaging.ListenerKind;
 
 @Component
-public class OrderListeners {
+public class InvoiceListener {
 
-    @Listener(name = "queue.orders", kind = ListenerKind.QUEUE)
-    public void onOrder(String body) {
-        // handle message
+    private final Auditor auditor;
+
+    public InvoiceListener(Auditor auditor) {
+        this.auditor = auditor;
+    }
+
+    @Listener(name = "java-invoice-queue", kind = ListenerKind.QUEUE)
+    public void onInvoice(String message) {
+        auditor.record("invoice received: " + message);
     }
 }
 ```
 
 Both styles give compile-time signature checking and a direct dispatch path. There is no reflective by-name fallback. See [`/sdk/messaging/decorators`](/sdk/messaging/decorators) for details.
+
+**Sample project:** [`dirigiblelabs/sample-java-listener-decorator`](https://github.com/dirigiblelabs/sample-java-listener-decorator) - `OrderListener` (interface style on `java-order-queue`) and `InvoiceListener` (method-level `@Listener` with an injected `Auditor`). SDK reference: [`/sdk/`](https://www.dirigible.io/sdk/).
 
 **TypeScript:**
 

--- a/docs/help/develop/rest-apis.md
+++ b/docs/help/develop/rest-apis.md
@@ -52,37 +52,57 @@ class CountryController {
 ```
 
 ```java
-package com.acme.demo;
+package demo;
 
-import org.eclipse.dirigible.sdk.http.Controller;
-import org.eclipse.dirigible.sdk.http.Get;
-import org.eclipse.dirigible.sdk.http.Post;
+import java.util.List;
+
+import org.eclipse.dirigible.sdk.component.Inject;
 import org.eclipse.dirigible.sdk.http.Body;
+import org.eclipse.dirigible.sdk.http.Controller;
+import org.eclipse.dirigible.sdk.http.Delete;
+import org.eclipse.dirigible.sdk.http.Get;
 import org.eclipse.dirigible.sdk.http.PathParam;
+import org.eclipse.dirigible.sdk.http.Post;
+import org.eclipse.dirigible.sdk.platform.Documentation;
+import org.eclipse.dirigible.sdk.security.Roles;
 
-@Controller("/countries")
+@Controller
+@Documentation("CRUD over the Country entity")
+@Roles({"DEVELOPER"})
 public class CountryController {
 
-    private final CountryRepository countries;
+    @Inject
+    private CountryRepository countries;
 
-    // collaborators are constructor-injected by the container
-    public CountryController(CountryRepository countries) {
-        this.countries = countries;
+    @Get("/")
+    @Documentation("Lists every Country")
+    public List<Country> list() {
+        return countries.findAll();
     }
 
     @Get("/{id}")
-    public Country byId(@PathParam("id") long id) {
+    @Documentation("Fetches a single country by id")
+    public Country byId(@PathParam("id") Long id) {
         return countries.findById(id);
     }
 
     @Post
+    @Documentation("Creates a new country from a JSON body")
     public Country create(@Body Country country) {
         return countries.save(country);
+    }
+
+    @Delete("/{id}")
+    @Documentation("Deletes the country with the given id")
+    public void remove(@PathParam("id") Long id) {
+        countries.deleteById(id);
     }
 }
 ```
 
-A `@Controller` is a managed bean, so it receives its repository or service through the constructor (field `@Inject` is also supported). See [Dependency injection](/help/develop/dependency-injection) for the full picture.
+A `@Controller` is a managed bean, so it receives its repository or service through the constructor or via field `@Inject` (shown above). See [Dependency injection](/help/develop/dependency-injection) for the full picture.
+
+**Sample project:** [`dirigiblelabs/sample-java-entity-decorators`](https://github.com/dirigiblelabs/sample-java-entity-decorators) - `CountryController` over a `JavaRepository`-backed `CountryRepository`. SDK reference: [`/sdk/`](https://www.dirigible.io/sdk/).
 
 ## Role-protected endpoints
 

--- a/docs/help/develop/rest-apis.md
+++ b/docs/help/develop/rest-apis.md
@@ -63,17 +63,26 @@ import org.eclipse.dirigible.sdk.http.PathParam;
 @Controller("/countries")
 public class CountryController {
 
+    private final CountryRepository countries;
+
+    // collaborators are constructor-injected by the container
+    public CountryController(CountryRepository countries) {
+        this.countries = countries;
+    }
+
     @Get("/{id}")
     public Country byId(@PathParam("id") long id) {
-        return new Country(id, "...");
+        return countries.findById(id);
     }
 
     @Post
     public Country create(@Body Country country) {
-        return country;
+        return countries.save(country);
     }
 }
 ```
+
+A `@Controller` is a managed bean, so it receives its repository or service through the constructor (field `@Inject` is also supported). See [Dependency injection](/help/develop/dependency-injection) for the full picture.
 
 ## Role-protected endpoints
 

--- a/docs/help/develop/rest-apis.md
+++ b/docs/help/develop/rest-apis.md
@@ -31,25 +31,9 @@ Type coercion handles `String`, primitive numerics, `UUID`, enums, and `boolean`
 - `String` / `CharSequence` - written as `text/plain`.
 - Anything else - serialized as JSON via Jackson.
 
-## TypeScript and Java side by side
+## Example
 
-```ts
-import { Controller, Get, Post, Body, PathParam } from "@aerokit/sdk/http/decorators";
-
-@Controller("/countries")
-class CountryController {
-
-  @Get("/{id}")
-  public byId(@PathParam("id") id: number) {
-    return { id, name: "..." };
-  }
-
-  @Post("/")
-  public create(@Body country: { name: string }) {
-    return country;
-  }
-}
-```
+### Java
 
 ```java
 package demo;
@@ -102,7 +86,29 @@ public class CountryController {
 
 A `@Controller` is a managed bean, so it receives its repository or service through the constructor or via field `@Inject` (shown above). See [Dependency injection](/help/develop/dependency-injection) for the full picture.
 
-**Sample project:** [`dirigiblelabs/sample-java-entity-decorators`](https://github.com/dirigiblelabs/sample-java-entity-decorators) - `CountryController` over a `JavaRepository`-backed `CountryRepository`. SDK reference: [`/sdk/`](https://www.dirigible.io/sdk/).
+**Sample project:** [`dirigiblelabs/sample-java-entity-decorators`](https://github.com/dirigiblelabs/sample-java-entity-decorators) - `CountryController` over a `JavaRepository`-backed `CountryRepository`. SDK reference: [`/sdk/http/`](https://www.dirigible.io/sdk/http/).
+
+### TypeScript / JavaScript
+
+```ts
+import { Controller, Get, Post, Body, PathParam } from "@aerokit/sdk/http/decorators";
+
+@Controller("/countries")
+class CountryController {
+
+  @Get("/{id}")
+  public byId(@PathParam("id") id: number) {
+    return { id, name: "..." };
+  }
+
+  @Post("/")
+  public create(@Body country: { name: string }) {
+    return country;
+  }
+}
+```
+
+API reference: [TypeScript API - http](/api/http/).
 
 ## Role-protected endpoints
 

--- a/docs/help/develop/scheduled-jobs.md
+++ b/docs/help/develop/scheduled-jobs.md
@@ -32,22 +32,26 @@ The modern approach is a `@Component` bean. There are exactly **two** styles. A 
 **Style 1 - self-describing interface.** A `@Component` that implements `JobHandler`. The interface carries the binding itself: `cron()` returns the schedule and `run()` does the work, so **no class-level `@Scheduled`** is used. This mirrors Spring's `org.quartz.Job`.
 
 ```java
-package com.acme.demo;
+package demo.scheduled;
 
 import org.eclipse.dirigible.sdk.component.Component;
 import org.eclipse.dirigible.sdk.job.JobHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component
-public class NightlyJob implements JobHandler {
+public class CleanupJob implements JobHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("app.out");
 
     @Override
     public String cron() {
-        return "0 0 * * * ?";
+        return "* * * * * ?";
     }
 
     @Override
     public void run() {
-        // work here
+        LOGGER.info("CleanupJob executed!");
     }
 }
 ```
@@ -55,22 +59,28 @@ public class NightlyJob implements JobHandler {
 **Style 2 - method-level `@Scheduled`.** `@Scheduled(expression = "…")` on a public no-arg method of a `@Component` (Spring `@Scheduled` style), so a single bean can hold several jobs alongside other logic and inject collaborators:
 
 ```java
-package com.acme.demo;
+package demo.scheduled;
 
 import org.eclipse.dirigible.sdk.component.Component;
 import org.eclipse.dirigible.sdk.job.Scheduled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component
-public class MaintenanceJobs {
+public class Maintenance {
 
-    @Scheduled(expression = "0 0 * * * ?")
-    public void nightly() {
-        // work here
+    private static final Logger LOGGER = LoggerFactory.getLogger("app.out");
+
+    @Scheduled(expression = "0/45 * * * * ?")
+    public void purgeTempFiles() {
+        LOGGER.info("Maintenance.purgeTempFiles executed (method-level @Scheduled)!");
     }
 }
 ```
 
 Both styles give compile-time signature checking and a direct dispatch path. There is no reflective by-name fallback. See [`/sdk/job/decorators`](/sdk/job/decorators) for details.
+
+**Sample project:** [`dirigiblelabs/sample-java-job-decorator`](https://github.com/dirigiblelabs/sample-java-job-decorator) - `CleanupJob` (interface style, fires every second) and `Maintenance` (method-level `@Scheduled`). SDK reference: [`/sdk/`](https://www.dirigible.io/sdk/).
 
 **TypeScript:**
 

--- a/docs/help/develop/scheduled-jobs.md
+++ b/docs/help/develop/scheduled-jobs.md
@@ -23,22 +23,27 @@ A JSON descriptor under the project points at a JS/TS/Java handler module and su
 
 Stop / start / reschedule from the Jobs perspective.
 
-## `@Scheduled` annotation
+## `@Component` job
 
-The modern approach is a class with a no-arg `public void run()` method:
+The modern approach is a `@Component` bean. There are exactly **two** styles. A class uses **one or the other, never both** - the engine rejects a class that mixes them.
 
-**Java** - two equivalent styles.
+**Java**
 
-Strong interface - a class annotated `@Scheduled` that implements `JobHandler`:
+**Style 1 - self-describing interface.** A `@Component` that implements `JobHandler`. The interface carries the binding itself: `cron()` returns the schedule and `run()` does the work, so **no class-level `@Scheduled`** is used. This mirrors Spring's `org.quartz.Job`.
 
 ```java
 package com.acme.demo;
 
+import org.eclipse.dirigible.sdk.component.Component;
 import org.eclipse.dirigible.sdk.job.JobHandler;
-import org.eclipse.dirigible.sdk.job.Scheduled;
 
-@Scheduled(expression = "0 0 * * * ?")
+@Component
 public class NightlyJob implements JobHandler {
+
+    @Override
+    public String cron() {
+        return "0 0 * * * ?";
+    }
 
     @Override
     public void run() {
@@ -47,7 +52,7 @@ public class NightlyJob implements JobHandler {
 }
 ```
 
-Method-level - `@Scheduled` on a method of a `@Component` bean (Spring `@Scheduled` style), so a single bean can hold several jobs alongside other logic and inject collaborators:
+**Style 2 - method-level `@Scheduled`.** `@Scheduled(expression = "…")` on a public no-arg method of a `@Component` (Spring `@Scheduled` style), so a single bean can hold several jobs alongside other logic and inject collaborators:
 
 ```java
 package com.acme.demo;
@@ -65,7 +70,7 @@ public class MaintenanceJobs {
 }
 ```
 
-`JobHandler` is the optional typed contract for `run()`. Implementing it (or using the method-level annotation) gives compile-time signature checking and a direct (non-reflective) dispatch path. The legacy plain `run()`-by-name convention still works - the runtime falls back to reflection when neither is present. See [`/sdk/job/decorators`](/sdk/job/decorators) for details.
+Both styles give compile-time signature checking and a direct dispatch path. There is no reflective by-name fallback. See [`/sdk/job/decorators`](/sdk/job/decorators) for details.
 
 **TypeScript:**
 

--- a/docs/help/develop/scheduled-jobs.md
+++ b/docs/help/develop/scheduled-jobs.md
@@ -27,7 +27,9 @@ Stop / start / reschedule from the Jobs perspective.
 
 The modern approach is a class with a no-arg `public void run()` method:
 
-**Java:**
+**Java** - two equivalent styles.
+
+Strong interface - a class annotated `@Scheduled` that implements `JobHandler`:
 
 ```java
 package com.acme.demo;
@@ -45,7 +47,25 @@ public class NightlyJob implements JobHandler {
 }
 ```
 
-`JobHandler` is the optional typed contract for `run()`. Implementing it gives compile-time signature checking and a direct (non-reflective) dispatch path. Plain `run()` by name still works - the runtime falls back to reflection when the interface isn't implemented. See [`/sdk/job/decorators`](/sdk/job/decorators) for details.
+Method-level - `@Scheduled` on a method of a `@Component` bean (Spring `@Scheduled` style), so a single bean can hold several jobs alongside other logic and inject collaborators:
+
+```java
+package com.acme.demo;
+
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.job.Scheduled;
+
+@Component
+public class MaintenanceJobs {
+
+    @Scheduled(expression = "0 0 * * * ?")
+    public void nightly() {
+        // work here
+    }
+}
+```
+
+`JobHandler` is the optional typed contract for `run()`. Implementing it (or using the method-level annotation) gives compile-time signature checking and a direct (non-reflective) dispatch path. The legacy plain `run()`-by-name convention still works - the runtime falls back to reflection when neither is present. See [`/sdk/job/decorators`](/sdk/job/decorators) for details.
 
 **TypeScript:**
 
@@ -79,6 +99,8 @@ Scheduled jobs are **tenant-isolated** - the same `.job` file under one project 
 
 ## See also
 
+- Working sample: [`dirigiblelabs/sample-java-job-decorator`](https://github.com/dirigiblelabs/sample-java-job-decorator).
 - [TypeScript API - job](/api/job/).
 - [Java SDK - job](/sdk/job/).
+- [SDK reference](https://www.dirigible.io/sdk/).
 - [Jobs perspective](/help/ide/perspectives/jobs).

--- a/docs/help/develop/security-and-roles.md
+++ b/docs/help/develop/security-and-roles.md
@@ -14,24 +14,9 @@ Both ultimately call `UserFacade.isInRole(role)` against whatever the platform's
 
 ## @Roles
 
-`@Roles` is **any-of**. The caller gains access if it holds at least one of the listed roles.
+`@Roles` is **any-of**. The caller gains access if it holds at least one of the listed roles. The annotation can sit on a `@Controller` class (gating every method) or on an individual method, and method-level `@Roles` overrides class-level for that method only. An empty list opens the endpoint up.
 
-```ts
-import { Controller, Get } from "@aerokit/sdk/http";
-import { Roles } from "@aerokit/sdk/security";
-
-@Roles(["admin", "ops"])
-@Controller
-class AdminController {
-
-    @Get("/users")
-    public listUsers() { /* ... */ }
-
-    @Roles([])
-    @Get("/health")
-    public health() { return "OK"; }
-}
-```
+### Java
 
 ```java
 import org.eclipse.dirigible.sdk.http.Controller;
@@ -51,8 +36,6 @@ public class AdminController {
 }
 ```
 
-Method-level `@Roles` overrides class-level for that method only. An empty list opens the endpoint up.
-
 In the entity sample the whole CRUD controller is gated to the built-in `DEVELOPER` role with a single class-level annotation:
 
 ```java
@@ -63,6 +46,25 @@ import org.eclipse.dirigible.sdk.security.Roles;
 @Roles({"DEVELOPER"})
 public class CountryController {
     // every endpoint requires the DEVELOPER (or ADMINISTRATOR) role
+}
+```
+
+### TypeScript / JavaScript
+
+```ts
+import { Controller, Get } from "@aerokit/sdk/http";
+import { Roles } from "@aerokit/sdk/security";
+
+@Roles(["admin", "ops"])
+@Controller
+class AdminController {
+
+    @Get("/users")
+    public listUsers() { /* ... */ }
+
+    @Roles([])
+    @Get("/health")
+    public health() { return "OK"; }
 }
 ```
 
@@ -79,15 +81,23 @@ A caller in either role passes every `@Roles` gate.
 
 When `Configuration.isAnonymousModeEnabled()` or `isAnonymousUserEnabled()` returns true, `@Roles` is bypassed entirely - useful for self-hosted dev setups. Normal mode requires authentication for every secured endpoint.
 
+This is a server-wide configuration switch, not a code-level API, so it behaves identically for Java and TypeScript/JavaScript controllers - there is nothing language-specific to call.
+
 ## Reading the current user
 
-```ts
-import { user } from "@aerokit/sdk/security";
+The Java `User` API (`org.eclipse.dirigible.sdk.security.User`) exposes the same surface as the TypeScript `user`, with all methods static. The same `UserFacade` underpins `@Roles` dispatch and the `User` SDK class on both languages, so the two never diverge:
 
-const name  = user.getName();
-const admin = user.isInRole("admin");
-const lang  = user.getLanguage();
-```
+| Method | Java `User` | TypeScript `user` |
+| --- | --- | --- |
+| Current user name | `User.getName()` | `user.getName()` |
+| Role check | `User.isInRole(role)` | `user.isInRole(role)` |
+| All roles | `User.getRoles()` | `user.getRoles()` |
+| Authentication type | `User.getAuthType()` | `user.getAuthType()` |
+| Security token | `User.getSecurityToken()` | `user.getSecurityToken()` |
+| Invocation count | `User.getInvocationCount()` | `user.getInvocationCount()` |
+| UI language | `User.getLanguage()` | `user.getLanguage()` |
+
+### Java
 
 ```java
 import org.eclipse.dirigible.sdk.security.User;
@@ -97,19 +107,15 @@ boolean admin = User.isInRole("admin");
 String lang  = User.getLanguage();
 ```
 
-The Java `User` API (`org.eclipse.dirigible.sdk.security.User`) exposes the same surface as the TypeScript `user`, with all methods static:
+### TypeScript / JavaScript
 
-| Method | TypeScript `user` | Java `User` |
-| --- | --- | --- |
-| Current user name | `user.getName()` | `User.getName()` |
-| Role check | `user.isInRole(role)` | `User.isInRole(role)` |
-| All roles | `user.getRoles()` | `User.getRoles()` |
-| Authentication type | `user.getAuthType()` | `User.getAuthType()` |
-| Security token | `user.getSecurityToken()` | `User.getSecurityToken()` |
-| Invocation count | `user.getInvocationCount()` | `User.getInvocationCount()` |
-| UI language | `user.getLanguage()` | `User.getLanguage()` |
+```ts
+import { user } from "@aerokit/sdk/security";
 
-The same `UserFacade` underpins `@Roles` dispatch and the `User` SDK class on both languages, so the two never diverge.
+const name  = user.getName();
+const admin = user.isInRole("admin");
+const lang  = user.getLanguage();
+```
 
 ## Declarative URL rules
 

--- a/docs/help/develop/security-and-roles.md
+++ b/docs/help/develop/security-and-roles.md
@@ -84,7 +84,19 @@ boolean admin = User.isInRole("admin");
 String lang  = User.getLanguage();
 ```
 
-The same `UserFacade` underpins `@Roles` dispatch and the `User` SDK class, so the two never diverge.
+The Java `User` API (`org.eclipse.dirigible.sdk.security.User`) exposes the same surface as the TypeScript `user`, with all methods static:
+
+| Method | TypeScript `user` | Java `User` |
+| --- | --- | --- |
+| Current user name | `user.getName()` | `User.getName()` |
+| Role check | `user.isInRole(role)` | `User.isInRole(role)` |
+| All roles | `user.getRoles()` | `User.getRoles()` |
+| Authentication type | `user.getAuthType()` | `User.getAuthType()` |
+| Security token | `user.getSecurityToken()` | `User.getSecurityToken()` |
+| Invocation count | `user.getInvocationCount()` | `User.getInvocationCount()` |
+| UI language | `user.getLanguage()` | `User.getLanguage()` |
+
+The same `UserFacade` underpins `@Roles` dispatch and the `User` SDK class on both languages, so the two never diverge.
 
 ## Declarative URL rules
 
@@ -93,3 +105,4 @@ For URL-pattern-based access that isn't bound to a specific controller method, u
 - See [`/help/artefacts/security/access`](/help/artefacts/security/access).
 - See [`/help/artefacts/security/roles`](/help/artefacts/security/roles).
 - See [`/help/concepts/security-model`](/help/concepts/security-model) for the bigger picture.
+- [SDK reference](https://www.dirigible.io/sdk/).

--- a/docs/help/develop/security-and-roles.md
+++ b/docs/help/develop/security-and-roles.md
@@ -53,6 +53,19 @@ public class AdminController {
 
 Method-level `@Roles` overrides class-level for that method only. An empty list opens the endpoint up.
 
+In the entity sample the whole CRUD controller is gated to the built-in `DEVELOPER` role with a single class-level annotation:
+
+```java
+import org.eclipse.dirigible.sdk.http.Controller;
+import org.eclipse.dirigible.sdk.security.Roles;
+
+@Controller
+@Roles({"DEVELOPER"})
+public class CountryController {
+    // every endpoint requires the DEVELOPER (or ADMINISTRATOR) role
+}
+```
+
 ## Built-in super-roles
 
 Two roles always exist and short-circuit any `@Roles` check:
@@ -105,4 +118,8 @@ For URL-pattern-based access that isn't bound to a specific controller method, u
 - See [`/help/artefacts/security/access`](/help/artefacts/security/access).
 - See [`/help/artefacts/security/roles`](/help/artefacts/security/roles).
 - See [`/help/concepts/security-model`](/help/concepts/security-model) for the bigger picture.
+
+## See also
+
+- Working sample: [`dirigiblelabs/sample-java-entity-decorators`](https://github.com/dirigiblelabs/sample-java-entity-decorators) - `CountryController` annotated `@Roles({"DEVELOPER"})`.
 - [SDK reference](https://www.dirigible.io/sdk/).

--- a/docs/help/develop/websockets.md
+++ b/docs/help/develop/websockets.md
@@ -16,47 +16,76 @@ An endpoint is a `@Component` bean. There are exactly **two** styles. A class us
 **Style 1 - self-describing interface.** A `@Component` that implements `WebsocketHandler`. The interface carries the binding itself: `endpoint()` returns the path suffix, and the four lifecycle callbacks (`onOpen` / `onMessage` / `onError` / `onClose`) are `default` no-ops you override only as needed, so **no class-level `@Websocket`** is used. This mirrors Spring's `TextWebSocketHandler`.
 
 ```java
-package com.acme.demo;
+package demo.websocket;
 
 import org.eclipse.dirigible.sdk.component.Component;
 import org.eclipse.dirigible.sdk.net.WebsocketHandler;
 
 @Component
-public class ChatEndpoint implements WebsocketHandler {
+public class ChatHandler implements WebsocketHandler {
 
     @Override
     public String endpoint() {
-        return "chat";
+        return "java-chat";
     }
 
     @Override
-    public void onMessage(String message, String sessionId) {
-        // route / broadcast
+    public void onOpen() {
+        System.out.println("ChatHandler: client connected");
     }
 
-    // onOpen / onError / onClose inherit the no-op default
+    @Override
+    public void onMessage(String message, String from) {
+        System.out.println("ChatHandler: " + from + " says: " + message);
+    }
+
+    @Override
+    public void onError(String error) {
+        System.out.println("ChatHandler: error: " + error);
+    }
+
+    @Override
+    public void onClose() {
+        System.out.println("ChatHandler: client disconnected");
+    }
 }
 ```
 
-**Style 2 - `@Websocket` class with method-level callbacks.** A `@Websocket(endpoint = "…")` class whose lifecycle callbacks are bound by the `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose` method annotations, so the bean only declares the callbacks it needs and can inject collaborators. Note the asymmetry: `@Websocket` remains a **class** annotation here because the endpoint has no method-level home (like Jakarta's `@ServerEndpoint`).
+Override only the callbacks you need; the rest inherit the no-op default. Clients connect at `/websockets/stomp/java-chat`.
+
+**Style 2 - `@Websocket` class with method-level callbacks.** A `@Websocket(endpoint = "…")` class whose lifecycle callbacks are bound by the `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose` method annotations, so the bean only declares the callbacks it needs and can inject collaborators. A non-`void` `@OnMessage` return value is sent back to the client. Note the asymmetry: `@Websocket` remains a **class** annotation here because the endpoint has no method-level home (like Jakarta's `@ServerEndpoint`).
 
 ```java
-package com.acme.demo;
+package demo.websocket;
 
-import org.eclipse.dirigible.sdk.net.Websocket;
+import org.eclipse.dirigible.sdk.net.OnClose;
 import org.eclipse.dirigible.sdk.net.OnMessage;
+import org.eclipse.dirigible.sdk.net.OnOpen;
+import org.eclipse.dirigible.sdk.net.Websocket;
 
-@Websocket(endpoint = "chat")
-public class ChatEndpoint {
+@Websocket(name = "Java Ticker", endpoint = "java-ticker")
+public class TickerHandler {
+
+    @OnOpen
+    public void opened() {
+        System.out.println("TickerHandler: client connected");
+    }
 
     @OnMessage
-    public void handle(String message, String sessionId) {
-        // route / broadcast
+    public String message(String message, String from) {
+        return "tick: " + message;
+    }
+
+    @OnClose
+    public void closed() {
+        System.out.println("TickerHandler: client disconnected");
     }
 }
 ```
 
 Both styles give compile-time signature checking and a direct dispatch path. There is no reflective by-name fallback. See [`/sdk/net/decorators`](/sdk/net/decorators) for details.
+
+**Sample project:** [`dirigiblelabs/sample-java-websocket-decorator`](https://github.com/dirigiblelabs/sample-java-websocket-decorator) - `ChatHandler` (interface style on `java-chat`) and `TickerHandler` (`@Websocket` with `@OnOpen` / `@OnMessage` / `@OnClose`). SDK reference: [`/sdk/`](https://www.dirigible.io/sdk/).
 
 **TypeScript:**
 

--- a/docs/help/develop/websockets.md
+++ b/docs/help/develop/websockets.md
@@ -7,22 +7,27 @@ description: Server WebSocket endpoints over STOMP.
 
 `engine-websockets` exposes user-defined endpoints under `/websockets/stomp/<suffix>`. Two declaration styles are supported.
 
-## `@Websocket` annotation
+## `@Component` endpoint
 
-A class exposing any combination of `onOpen()`, `onMessage(String, String)`, `onError(String)`, `onClose()`.
+An endpoint is a `@Component` bean. There are exactly **two** styles. A class uses **one or the other, never both** - the engine rejects a class that mixes them.
 
-**Java** - two equivalent styles.
+**Java**
 
-Strong interface - a class annotated `@Websocket` that implements `WebsocketHandler`:
+**Style 1 - self-describing interface.** A `@Component` that implements `WebsocketHandler`. The interface carries the binding itself: `endpoint()` returns the path suffix, and the four lifecycle callbacks (`onOpen` / `onMessage` / `onError` / `onClose`) are `default` no-ops you override only as needed, so **no class-level `@Websocket`** is used. This mirrors Spring's `TextWebSocketHandler`.
 
 ```java
 package com.acme.demo;
 
-import org.eclipse.dirigible.sdk.net.Websocket;
+import org.eclipse.dirigible.sdk.component.Component;
 import org.eclipse.dirigible.sdk.net.WebsocketHandler;
 
-@Websocket(name = "chat", endpoint = "chat")
+@Component
 public class ChatEndpoint implements WebsocketHandler {
+
+    @Override
+    public String endpoint() {
+        return "chat";
+    }
 
     @Override
     public void onMessage(String message, String sessionId) {
@@ -33,17 +38,15 @@ public class ChatEndpoint implements WebsocketHandler {
 }
 ```
 
-Method-level - `@Websocket` on a `@Component` bean with the lifecycle callbacks bound by the `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose` method annotations, so the bean only declares the callbacks it needs and can inject collaborators:
+**Style 2 - `@Websocket` class with method-level callbacks.** A `@Websocket(endpoint = "…")` class whose lifecycle callbacks are bound by the `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose` method annotations, so the bean only declares the callbacks it needs and can inject collaborators. Note the asymmetry: `@Websocket` remains a **class** annotation here because the endpoint has no method-level home (like Jakarta's `@ServerEndpoint`).
 
 ```java
 package com.acme.demo;
 
-import org.eclipse.dirigible.sdk.component.Component;
 import org.eclipse.dirigible.sdk.net.Websocket;
 import org.eclipse.dirigible.sdk.net.OnMessage;
 
-@Component
-@Websocket(name = "chat", endpoint = "chat")
+@Websocket(endpoint = "chat")
 public class ChatEndpoint {
 
     @OnMessage
@@ -53,7 +56,7 @@ public class ChatEndpoint {
 }
 ```
 
-`WebsocketHandler` is the optional typed contract for the four lifecycle callbacks. All its methods are `default` no-ops, so handlers only override what they need - no empty stubs. The method-level `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose` annotations are the alternative. Classes that use neither still work via the legacy method-by-name reflective dispatch. See [`/sdk/net/decorators`](/sdk/net/decorators) for details.
+Both styles give compile-time signature checking and a direct dispatch path. There is no reflective by-name fallback. See [`/sdk/net/decorators`](/sdk/net/decorators) for details.
 
 **TypeScript:**
 

--- a/docs/help/develop/websockets.md
+++ b/docs/help/develop/websockets.md
@@ -11,7 +11,9 @@ description: Server WebSocket endpoints over STOMP.
 
 A class exposing any combination of `onOpen()`, `onMessage(String, String)`, `onError(String)`, `onClose()`.
 
-**Java:**
+**Java** - two equivalent styles.
+
+Strong interface - a class annotated `@Websocket` that implements `WebsocketHandler`:
 
 ```java
 package com.acme.demo;
@@ -31,7 +33,27 @@ public class ChatEndpoint implements WebsocketHandler {
 }
 ```
 
-`WebsocketHandler` is the optional typed contract for the four lifecycle callbacks. All methods are `default` no-ops, so handlers only override what they need - no empty stubs. Classes that don't implement the interface still work via the same method-by-name reflective dispatch. See [`/sdk/net/decorators`](/sdk/net/decorators) for details.
+Method-level - `@Websocket` on a `@Component` bean with the lifecycle callbacks bound by the `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose` method annotations, so the bean only declares the callbacks it needs and can inject collaborators:
+
+```java
+package com.acme.demo;
+
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.net.Websocket;
+import org.eclipse.dirigible.sdk.net.OnMessage;
+
+@Component
+@Websocket(name = "chat", endpoint = "chat")
+public class ChatEndpoint {
+
+    @OnMessage
+    public void handle(String message, String sessionId) {
+        // route / broadcast
+    }
+}
+```
+
+`WebsocketHandler` is the optional typed contract for the four lifecycle callbacks. All its methods are `default` no-ops, so handlers only override what they need - no empty stubs. The method-level `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose` annotations are the alternative. Classes that use neither still work via the legacy method-by-name reflective dispatch. See [`/sdk/net/decorators`](/sdk/net/decorators) for details.
 
 **TypeScript:**
 
@@ -69,5 +91,7 @@ Both declarations are hot-reloaded - the endpoint is reinstalled on every change
 
 ## See also
 
+- Working sample: [`dirigiblelabs/sample-java-websocket-decorator`](https://github.com/dirigiblelabs/sample-java-websocket-decorator).
 - [TypeScript API - net](/api/).
 - [Java SDK - net](/sdk/).
+- [SDK reference](https://www.dirigible.io/sdk/).

--- a/docs/help/develop/working-with-data.md
+++ b/docs/help/develop/working-with-data.md
@@ -40,23 +40,9 @@ Pair a `*.csvim` (the model) with one or more `*.csv` files. See [`/help/artefac
 
 ## Running SQL from user code
 
-Use the SDK's `db` modules.
+Use the SDK's `db` modules. Both runtimes expose the same `Database.getConnection()` entry point.
 
-```ts
-import { Database } from "@aerokit/sdk/db";
-
-const conn = Database.getConnection();
-try {
-    const stmt = conn.prepareStatement("SELECT id, name FROM countries WHERE active = ?");
-    stmt.setBoolean(1, true);
-    const rows = stmt.executeQuery();
-    while (rows.next()) {
-        console.log(rows.getLong("id"), rows.getString("name"));
-    }
-} finally {
-    conn.close();
-}
-```
+### Java
 
 ```java
 import org.eclipse.dirigible.sdk.db.Database;
@@ -76,11 +62,25 @@ try (Connection conn = Database.getConnection()) {
 }
 ```
 
+### TypeScript / JavaScript
+
+```ts
+import { Database } from "@aerokit/sdk/db";
+
+const conn = Database.getConnection();
+try {
+    const stmt = conn.prepareStatement("SELECT id, name FROM countries WHERE active = ?");
+    stmt.setBoolean(1, true);
+    const rows = stmt.executeQuery();
+    while (rows.next()) {
+        console.log(rows.getLong("id"), rows.getString("name"));
+    }
+} finally {
+    conn.close();
+}
+```
+
 For typed entity CRUD use the entity store - see [`/help/develop/entities-and-persistence`](/help/develop/entities-and-persistence).
-
-## Multi-tenancy
-
-User data sources are **tenant-isolated** by default. Each tenant's calls to `Database.getConnection()` resolve to its own pool. The SystemDB stays system-level. See [`/help/concepts/multi-tenancy`](/help/concepts/multi-tenancy).
 
 ## Supported databases
 

--- a/docs/help/develop/working-with-files-and-cms.md
+++ b/docs/help/develop/working-with-files-and-cms.md
@@ -66,10 +66,6 @@ const root = session.getRootFolder();
 const doc = root.createDocument({ name: "report.pdf" }, pdfBytes, "application/pdf");
 ```
 
-## Tenant isolation
-
-CMS storage is **tenant-isolated** when multi-tenancy is on (default). Each tenant's CMIS root resolves to its own folder under the configured root. See [`/help/concepts/multi-tenancy`](/help/concepts/multi-tenancy).
-
 ## See also
 
 - [`@aerokit/sdk/io/files`](/api/io/files)

--- a/docs/help/develop/working-with-files-and-cms.md
+++ b/docs/help/develop/working-with-files-and-cms.md
@@ -9,14 +9,9 @@ Two separate surfaces. Use `io` when you want bytes on the host filesystem. Use 
 
 ## Filesystem IO
 
-```ts
-import { Files, Streams } from "@aerokit/sdk/io";
+Both runtimes expose the same `Files` entry point for host-filesystem access.
 
-if (!Files.exists("/tmp/orders.json")) {
-    Files.writeText("/tmp/orders.json", JSON.stringify({ orders: [] }));
-}
-const data = Files.readText("/tmp/orders.json");
-```
+### Java
 
 ```java
 import org.eclipse.dirigible.sdk.io.Files;
@@ -27,21 +22,28 @@ if (!Files.exists("/tmp/orders.json")) {
 String data = Files.readText("/tmp/orders.json");
 ```
 
+### TypeScript / JavaScript
+
+```ts
+import { Files, Streams } from "@aerokit/sdk/io";
+
+if (!Files.exists("/tmp/orders.json")) {
+    Files.writeText("/tmp/orders.json", JSON.stringify({ orders: [] }));
+}
+const data = Files.readText("/tmp/orders.json");
+```
+
 Paths are resolved against the JVM's working directory - not the registry. For platform-managed storage prefer the registry or repository surface; for transient files inside a tenant prefer CMS.
 
 See [`@aerokit/sdk/io`](/api/io/) and [`org.eclipse.dirigible.sdk.io`](/sdk/io/).
 
 ## CMS (CMIS)
 
-The Documents perspective and the CMIS SDK module both talk to the same `CmsProvider`. Configure once via `DIRIGIBLE_CMS_*` env vars; switch backend by selecting Internal (local folders), S3, or SharePoint.
+The Documents perspective and the CMIS SDK module both talk to the same `CmsProvider`. Configure once via `DIRIGIBLE_CMS_*` env vars; switch backend by selecting Internal (local folders), S3, or SharePoint. Both runtimes obtain the session through `Cmis.getSession()`.
 
-```ts
-import { Cmis } from "@aerokit/sdk/cms";
+### Java
 
-const session = Cmis.getSession();
-const root = session.getRootFolder();
-const doc = root.createDocument({ name: "report.pdf" }, pdfBytes, "application/pdf");
-```
+The Java side returns the raw `org.apache.chemistry.opencmis.client.api.Session` - you get the full Apache Chemistry API surface.
 
 ```java
 import org.eclipse.dirigible.sdk.cms.Cmis;
@@ -54,7 +56,15 @@ Folder root = session.getRootFolder();
 // root.createDocument(properties, contentStream, VersioningState.MAJOR);
 ```
 
-The Java side returns the raw `org.apache.chemistry.opencmis.client.api.Session` - you get the full Apache Chemistry API surface.
+### TypeScript / JavaScript
+
+```ts
+import { Cmis } from "@aerokit/sdk/cms";
+
+const session = Cmis.getSession();
+const root = session.getRootFolder();
+const doc = root.createDocument({ name: "report.pdf" }, pdfBytes, "application/pdf");
+```
 
 ## Tenant isolation
 

--- a/docs/help/develop/working-with-git.md
+++ b/docs/help/develop/working-with-git.md
@@ -13,13 +13,9 @@ The [Git perspective](/help/ide/perspectives/git) provides the everyday flow: cl
 
 ## From user code
 
-```ts
-import { Git } from "@aerokit/sdk/git";
+Both runtimes expose the same `Git` facade with matching method signatures.
 
-Git.cloneRepository("myws", "https://github.com/acme/svc.git", "user", "token", "main");
-Git.commit("alice", "alice@acme.com", "myws", "svc", "tighten validation", true);
-Git.push("myws", "svc", "user", "token");
-```
+### Java
 
 ```java
 import org.eclipse.dirigible.sdk.git.Git;
@@ -38,7 +34,19 @@ import java.util.List;
 List<GitCommitInfo> history = Git.getHistory("svc", "myws", "src/Main.java");
 ```
 
+### TypeScript / JavaScript
+
+```ts
+import { Git } from "@aerokit/sdk/git";
+
+Git.cloneRepository("myws", "https://github.com/acme/svc.git", "user", "token", "main");
+Git.commit("alice", "alice@acme.com", "myws", "svc", "tighten validation", true);
+Git.push("myws", "svc", "user", "token");
+```
+
 ## File content at a specific revision
+
+The same `Git` facade reads a file at a given revision on both runtimes - the Java form:
 
 ```java
 String content = Git.getFileContent("myws", "svc", "src/Main.java", "HEAD~3");

--- a/docs/help/extend/extension-points-deep-dive.md
+++ b/docs/help/extend/extension-points-deep-dive.md
@@ -47,7 +47,7 @@ String[] modules = Extensions.getExtensions("reports.exporter");
 
 ## Contracts
 
-For typed Java extension points the contract is the **interface** the contribution implements. Mark it with `@ExtensionPoint` and document expectations in its Javadoc - consumers receive typed instances from `Extensions.find(Class)` and call contract methods directly.
+For typed Java extension points the contract is the **interface** the contribution implements - a plain interface, no annotation. A contribution is a `@Component` bean that implements it; document expectations in the interface's Javadoc. Consumers receive typed instances by collection injection (`List<ReportExporter>`) or from `Extensions.find(Class)` and call contract methods directly.
 
 For string-keyed extension points the point owner publishes the contract by convention (a README, an `*.extensionpoint` description, a `@Documentation` annotation). Common patterns:
 

--- a/docs/help/get-started/first-application.md
+++ b/docs/help/get-started/first-application.md
@@ -68,9 +68,9 @@ Swagger UI is at `http://localhost:8080/swagger-ui/index.html`.
 The same endpoint in client Java (`HelloController.java`):
 
 ```java
-import org.eclipse.dirigible.engine.java.annotations.http.Controller;
-import org.eclipse.dirigible.engine.java.annotations.http.Get;
-import org.eclipse.dirigible.engine.java.annotations.http.PathParam;
+import org.eclipse.dirigible.sdk.http.Controller;
+import org.eclipse.dirigible.sdk.http.Get;
+import org.eclipse.dirigible.sdk.http.PathParam;
 
 import java.util.Map;
 

--- a/docs/help/get-started/next-steps.md
+++ b/docs/help/get-started/next-steps.md
@@ -13,7 +13,7 @@ With Dirigible running and a first endpoint published, the deep-dive sections ar
 
 ## Build with code
 
-- **[Develop](/help/develop/)** - the decorator model in TypeScript (`@aerokit/sdk/*`) and Java (`org.eclipse.dirigible.engine.java.annotations.*`). REST controllers, entities, repositories, scheduled jobs, listeners, components.
+- **[Develop](/help/develop/)** - the decorator / annotation model in TypeScript (`@aerokit/sdk/*`) and Java (`org.eclipse.dirigible.sdk.*`). REST controllers, entities, repositories, scheduled jobs, listeners, components.
 - **[Artefacts](/help/artefacts/)** - full catalogue of file extensions the platform recognises (`.job`, `.bpmn`, `.camel`, `.listener`, `.odata`, `.datasource`, `.table`, `.csvim`, ...) and how each is reconciled.
 - **[SDKs](/sdk/)** - Java SDK landing. The [API reference](/api/) covers the TypeScript / JavaScript surface (`@aerokit/sdk/*`).
 

--- a/docs/help/reference/artefact-extensions.md
+++ b/docs/help/reference/artefact-extensions.md
@@ -27,8 +27,8 @@ One row per file extension. For full per-artefact docs see the page in the `Arte
 | `expose` (project root) | [Expose static resources](/help/artefacts/services/expose) | `engine-web` | `ExposesSynchronizer` |
 | `*.extensionpoint`, `*.extension` | [Extensions](/help/artefacts/extensibility/) | `core-extensions` | `ExtensionPointsSynchronizer`, `ExtensionsSynchronizer` |
 | `*Component.ts` | [TS component](/help/artefacts/extensibility/component) | `engine-di` | `ComponentSynchronizer` |
-| `*Entity.ts`, `@Entity` Java | Entity persistence | `data-store` / `data-store-java` | `EntitySynchronizer`, `EntityClassConsumer` |
-| `*Controller.ts`, `@Controller` Java | REST controller -> auto OpenAPI | `engine-openapi` | `OpenAPISynchronizer` (+ `ControllerClassConsumer` for Java) |
+| `*Entity.ts`, `@Entity` Java | Entity persistence | `data-store` / `data-store-java` | `EntitySynchronizer` (TS); client-Java built by the `ComponentContainer` |
+| `*Controller.ts`, `@Controller` Java | REST controller -> auto OpenAPI | `engine-openapi` | `OpenAPISynchronizer` (TS); client-Java `@Controller` built by the `ComponentContainer` |
 
 ## Data
 

--- a/docs/help/reference/glossary.md
+++ b/docs/help/reference/glossary.md
@@ -35,7 +35,7 @@ description: One-line definitions of platform terms.
 
 **Annotation** - The Java equivalent of a decorator. Same names, same semantics, ships under `org.eclipse.dirigible.sdk.*`.
 
-**Extension point** - A named hook other artefacts can contribute to. Declared by `*.extensionpoint`; satisfied by `*.extension` or `@Extension`-annotated classes.
+**Extension point** - A named hook other artefacts can contribute to. Declared by `*.extensionpoint` (or, for typed Java, a plain interface); satisfied by `*.extension` artefacts or, in Java, by `@Component` beans that implement the interface.
 
 **Component** - A dependency-injected TS singleton declared via `*Component.ts` and the `@Component(...)` decorator. Java counterpart: `@Repository`.
 

--- a/docs/help/tutorials/rest-with-java-controllers.md
+++ b/docs/help/tutorials/rest-with-java-controllers.md
@@ -1,11 +1,11 @@
 ---
 title: REST with Java controllers
-description: Build a REST endpoint in Java using @Controller / @Get / @Post + @Inject.
+description: Build a REST endpoint in Java using @Controller / @Get / @Post + constructor injection.
 ---
 
 # REST with Java controllers
 
-A 5-minute walkthrough: a Java `@Controller` with a JPA-style entity, an `@Inject`ed repository, and full CRUD.
+A 5-minute walkthrough: a Java `@Controller` with a JPA-style entity, a constructor-injected repository, and full CRUD.
 
 ## 1. Create a project
 
@@ -52,47 +52,46 @@ Create `countries-java/com/acme/CountryRepository.java`:
 package com.acme;
 
 import org.eclipse.dirigible.sdk.component.Repository;
-import org.eclipse.dirigible.components.data.store.JavaEntityStore;
-import org.eclipse.dirigible.components.base.spring.BeanProvider;
-
-import java.util.List;
+import org.eclipse.dirigible.components.data.store.java.repository.JavaRepository;
 
 @Repository
-public class CountryRepository {
+public class CountryRepository extends JavaRepository<Country> {
 
-    private final JavaEntityStore store = BeanProvider.getBean(JavaEntityStore.class);
-
-    public Country save(Country c)        { store.save(c); return c; }
-    public Country update(Country c)      { store.update(c); return c; }
-    public Country get(Long id)           { return store.get(Country.class, id); }
-    public List<Country> list()           { return store.list(Country.class); }
-    public void delete(Long id)           { store.delete(Country.class, id); }
+    public CountryRepository() {
+        super(Country.class);
+    }
 }
 ```
+
+`JavaRepository<T>` ships typed CRUD out of the box - `findAll`, `findById`, `save`, `update`, `delete`, `deleteById`, `count`, `query`/HQL - so the repository needs no body unless you add domain methods.
 
 ## 4. Add a controller
 
 Create `countries-java/com/acme/CountryController.java`:
 
+Constructor injection is the preferred way to receive the repository:
+
 ```java
 package com.acme;
 
 import org.eclipse.dirigible.sdk.http.*;
-import org.eclipse.dirigible.sdk.component.Inject;
 
 import java.util.List;
 
 @Controller("/countries")
 public class CountryController {
 
-    @Inject
-    private CountryRepository repository;
+    private final CountryRepository repository;
+
+    public CountryController(CountryRepository repository) {
+        this.repository = repository;
+    }
 
     @Get
-    public List<Country> list() { return repository.list(); }
+    public List<Country> list() { return repository.findAll(); }
 
     @Get("/{id}")
-    public Country get(@PathParam("id") long id) { return repository.get(id); }
+    public Country get(@PathParam("id") long id) { return repository.findById(id); }
 
     @Post
     public Country create(@Body Country country) { return repository.save(country); }
@@ -104,9 +103,11 @@ public class CountryController {
     }
 
     @Delete("/{id}")
-    public void remove(@PathParam("id") long id) { repository.delete(id); }
+    public void remove(@PathParam("id") long id) { repository.deleteById(id); }
 }
 ```
+
+Field injection with `@Inject` (`org.eclipse.dirigible.sdk.component.Inject`) is also valid; constructor injection is preferred.
 
 ## 5. Publish
 

--- a/docs/sdk/component/beans.md
+++ b/docs/sdk/component/beans.md
@@ -1,0 +1,88 @@
+# Beans
+
+## Overview
+
+::: tip Module
+- package: `org.eclipse.dirigible.sdk.component`
+- source: [component/Beans.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/component/Beans.java)
+:::
+
+`Beans` is the client-facing facade for looking up managed beans and platform services from code. Use it when constructor or field [`@Inject`](/sdk/component/decorators) is not an option - for example inside a handler method that needs an `IRepository`, or to reach a platform service from a non-bean class.
+
+::: warning Use `Beans`, not `BeanProvider`
+Client code must use `Beans` for lookups. The platform-internal `BeanProvider` is not part of the client SDK and must not be referenced from client `.java` sources.
+:::
+
+### Example Usage:
+```java
+import org.eclipse.dirigible.sdk.component.Beans;
+
+// by type
+CountryRepository countries = Beans.get(CountryRepository.class);
+
+// by name and type
+CountryController controller = Beans.get("countryController", CountryController.class);
+
+// every bean assignable to the type
+List<OrderProcessor> processors = Beans.getAll(OrderProcessor.class);
+```
+
+Prefer [`@Inject`](/sdk/component/decorators) - and, for "all contributions of a type", `List<T>` injection - over `Beans.get` / `Beans.getAll` in classes that are themselves managed beans; reach for the facade only where injection cannot reach.
+
+## Methods
+
+### get()
+
+Returns the single bean of the given type.
+
+> ```java
+> public static <T> T get(Class<T> type);
+> ```
+>
+> | Parameter | Type | Description |
+> | ------ | ------ | ------ |
+> | `type` | `Class<T>` | The bean type to resolve. |
+>
+> ::: info Returns
+> - **Type**: `T`
+> - **Description**: The bean assignable to `type`.
+> :::
+
+### get() (by name)
+
+Returns the bean registered under the given name, cast to the given type.
+
+> ```java
+> public static <T> T get(String name, Class<T> type);
+> ```
+>
+> | Parameter | Type | Description |
+> | ------ | ------ | ------ |
+> | `name` | `String` | The bean name (see [`@Component`](/sdk/component/decorators) `value()`). |
+> | `type` | `Class<T>` | The expected bean type. |
+>
+> ::: info Returns
+> - **Type**: `T`
+> - **Description**: The named bean.
+> :::
+
+### getAll()
+
+Returns every bean assignable to the given type.
+
+> ```java
+> public static <T> List<T> getAll(Class<T> type);
+> ```
+>
+> | Parameter | Type | Description |
+> | ------ | ------ | ------ |
+> | `type` | `Class<T>` | The type to match against. |
+>
+> ::: info Returns
+> - **Type**: `List<T>`
+> - **Description**: All beans assignable to `type`. Same set you would receive from `List<T>` injection.
+> :::
+
+## See also
+
+- [Decorators](/sdk/component/decorators) - `@Component` / `@Inject` / `@Repository`.

--- a/docs/sdk/component/decorators.md
+++ b/docs/sdk/component/decorators.md
@@ -4,33 +4,38 @@
 
 ::: tip Module
 - package: `org.eclipse.dirigible.sdk.component`
-- source: [component/Inject.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/component/Inject.java) · [component/Repository.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/component/Repository.java)
+- source: [component/Component.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/component/Component.java) · [component/Inject.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/component/Inject.java) · [component/Repository.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/component/Repository.java)
 :::
 
-Dirigible's own dependency-injection annotations. The engine resolves `@Inject` fields through its `DependencyResolver` SPI at class-load time; `@Repository` registers a class as a singleton candidate for injection.
+Dirigible's own Spring-style dependency-injection annotations. A client class marked `@Component` becomes a managed bean; the engine instantiates it once per `ClientClassLoader` generation (a singleton) and resolves its `@Inject` points from the other beans of the same generation.
 
-Client classes are **not** Spring-scanned, so Spring's `@Autowired` would silently no-op - `@Inject` from this module is the load-bearing annotation.
+Client classes are **not** Spring-scanned, so Spring's `@Autowired` would silently no-op - the annotations from this module are the load-bearing ones.
 
 ### Example Usage:
 ```java
+import org.eclipse.dirigible.sdk.component.Component;
 import org.eclipse.dirigible.sdk.component.Inject;
 import org.eclipse.dirigible.sdk.component.Repository;
 import org.eclipse.dirigible.sdk.http.Controller;
 import org.eclipse.dirigible.sdk.http.Get;
 import org.eclipse.dirigible.components.data.store.java.repository.JavaRepository;
 
-// 1. Typed repository - subclasses JavaRepository<T> for free CRUD
+// 1. A repository is a managed bean in its own right
 @Repository
 public class CountryRepository extends JavaRepository<Country> {
     public CountryRepository() { super(Country.class); }
 }
 
-// 2. Controller injects the repository by field type
+// 2. A controller injects the repository through its constructor (preferred)
 @Controller
 public class CountryController {
 
+    private final CountryRepository countries;
+
     @Inject
-    private CountryRepository countries;
+    public CountryController(CountryRepository countries) {
+        this.countries = countries;
+    }
 
     @Get("/")
     public List<Country> list() {
@@ -39,24 +44,50 @@ public class CountryController {
 }
 ```
 
-## @Inject
+## @Component
 
-Marks a field on a client class as needing dependency injection. The field's declared type is resolved through the engine's `DependencyResolver` SPI at class-load time.
+Marks a client class as a managed bean. The runtime instantiates it once per `ClientClassLoader` generation (a singleton) and makes it available to every `@Inject` point.
 
 > ```java
 > @Retention(RetentionPolicy.RUNTIME)
-> @Target(ElementType.FIELD)
+> @Target(ElementType.TYPE)
+> public @interface Component {
+>     String value() default "";
+> }
+> ```
+
+### Attributes
+
+| Attribute | Type | Default | Description |
+| ------ | ------ | ------ | ------ |
+| `value` | `String` | `""` | Optional bean name. When omitted the name is the decapitalized simple class name (`CountryController` → `countryController`), following the Spring convention. |
+
+### Notes
+
+- `@Controller`, `@Repository`, and the marker on a job / listener / websocket handler are all beans - they participate in the same container.
+- Lifecycle callbacks `@PostConstruct` and `@PreDestroy` (`jakarta.annotation.*`) are honoured: `@PostConstruct` runs after the bean's dependencies are injected, `@PreDestroy` runs when its generation is torn down on hot-reload.
+
+## @Inject
+
+Requests dependency injection at the marked point. Valid on a **field**, a **constructor**, or a **constructor parameter**. Constructor injection is preferred - it keeps the collaborators `final` and the bean fully initialized before any method runs.
+
+> ```java
+> @Retention(RetentionPolicy.RUNTIME)
+> @Target({ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.PARAMETER})
 > public @interface Inject { }
 > ```
 
 ### Notes
 
-- Unlike Spring's `@Autowired`, this injection happens through the engine's own SPI - client classes are not Spring-scanned, so `@Autowired` would silently no-op.
-- Presently fulfilled by repositories from `data-store-java`, but the SPI is open for further consumers.
+- The declared type is matched against the beans of the current generation.
+- **Collection injection**: an injection point typed as `List<T>`, `Set<T>`, or `Collection<T>` receives **every** bean assignable to `T`. This is the idiomatic way to gather all contributions to an interface (see the [extensions](/sdk/extensions/) model).
+- Unlike Spring's `@Autowired`, this injection happens through the engine's own container - client classes are not Spring-scanned, so `@Autowired` would silently no-op.
 
 ## @Repository
 
-Marks a client class as a singleton repository discoverable via `@Inject`. The canonical use case is a class that extends `JavaRepository<T>` from `data-store-java` to expose typed CRUD over a Dirigible `@Entity`, but the annotation is engine-level so non-entity components can plug into the same injection mechanism.
+Marks a `@Component` that is a data repository. The canonical use case is a concrete class that extends `JavaRepository<T>` from `data-store-java` to expose typed CRUD over a Dirigible `@Entity`.
+
+A `@Repository` is a managed bean in its own right - it is injected exactly like any other bean (no separate registration mechanism).
 
 > ```java
 > @Retention(RetentionPolicy.RUNTIME)
@@ -66,6 +97,5 @@ Marks a client class as a singleton repository discoverable via `@Inject`. The c
 
 ### Notes
 
-- The `data-store-java` module ships a `RepositoryClassConsumer` that instantiates annotated classes via the public no-arg constructor and registers them in a `RepositoryRegistry`.
-- The registry implements `DependencyResolver`, so the controller consumer can satisfy `@Inject` field bindings.
+- Inject a repository wherever you need it: `@Inject CountryRepository countries` (constructor or field).
 - `JavaRepository<T>` provides `findAll`, `findAll(limit, offset)`, `findById(id)`, `findOne(id)`, `save(entity)`, `update(entity)`, `delete(entity)`, `deleteById(id)`, `count()`, and `query(hql, params)`. Sample: [`dirigiblelabs/sample-java-entity-decorators`](https://github.com/dirigiblelabs/sample-java-entity-decorators).

--- a/docs/sdk/component/index.md
+++ b/docs/sdk/component/index.md
@@ -7,12 +7,14 @@
 - source: [component/](https://github.com/eclipse/dirigible/tree/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/component)
 :::
 
-This module provides the Dirigible-native dependency-injection annotations. The runtime resolves `@Inject` fields through the engine's `DependencyResolver` SPI - singleton repositories declared with `@Repository` are the primary providers.
+This module provides Dirigible's Spring-style dependency-injection surface for client Java code. A class marked `@Component` becomes a managed bean (a singleton per `ClientClassLoader` generation); the runtime resolves its `@Inject` points - by field, constructor, or constructor parameter - from the other beans of the same generation. A `List<T>` / `Set<T>` / `Collection<T>` injection point receives every bean assignable to `T`.
 
 Client classes are **not** Spring-scanned, so Spring's `@Autowired` would silently no-op here. Use these annotations instead.
 
 The main components of this module are:
-- **@Inject**: Field annotation requesting injection by declared type.
-- **@Repository**: Type annotation registering a singleton component as a candidate for injection.
+- **@Component**: Type annotation that registers a class as a managed bean (optional `value()` bean name).
+- **@Inject**: Requests injection on a field, constructor, or constructor parameter (constructor injection preferred).
+- **@Repository**: A managed bean that is a data repository (typically extends `JavaRepository<T>`); injectable like any bean.
+- **Beans**: Static facade for looking up beans / platform services - `get(Class)`, `get(String, Class)`, `getAll(Class)`. The client-facing replacement for the platform-internal `BeanProvider`.
 
 ## Classes

--- a/docs/sdk/db/store.md
+++ b/docs/sdk/db/store.md
@@ -9,7 +9,7 @@
 
 `Store` is the untyped, Hibernate-backed CRUD facade for dynamic entities. Each call addresses an entity by its logical name (matching the `name()` attribute of an `@Entity` annotation on a registered client class) and exchanges data as JSON strings - a convenient shape for scripted callers and for endpoints that proxy arbitrary entity names.
 
-For typed CRUD over an `@Entity`-annotated client class with compile-time field checks, prefer `org.eclipse.dirigible.components.data.store.java.JavaEntityStore` (resolve it through `BeanProvider.getBean(JavaEntityStore.class)` inside a controller method). The two stores sit on the same Hibernate session - changes from one are immediately visible to the other.
+For typed CRUD over an `@Entity`-annotated client class with compile-time field checks, prefer a `@Repository` extending `JavaRepository<T>` and inject it. To reach the underlying `JavaEntityStore` directly, resolve it with `Beans.get(JavaEntityStore.class)` inside a bean method - use the client-facing `Beans` facade, not the platform-internal `BeanProvider`. The two stores sit on the same Hibernate session - changes from one are immediately visible to the other.
 
 ### Key Features:
 - **Entity-by-name addressing**: Operate on any registered `@Entity` without compile-time coupling to its class.

--- a/docs/sdk/extensions/decorators.md
+++ b/docs/sdk/extensions/decorators.md
@@ -1,76 +1,63 @@
-# Decorators
+# Extension model
 
 ## Overview
 
 ::: tip Module
 - package: `org.eclipse.dirigible.sdk.extensions`
-- source: [extensions/Extension.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/extensions/Extension.java), [extensions/ExtensionPoint.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/extensions/ExtensionPoint.java)
+- source: [extensions/](https://github.com/eclipse/dirigible/tree/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/extensions)
 :::
 
-Two paired annotations make up the typed extension surface:
+There is **no extension annotation** in the Java SDK. Extension points and contributions are expressed with the same building blocks as everything else - plain interfaces and [`@Component`](/sdk/component/decorators) beans:
 
-- `@ExtensionPoint` marks an **interface** that defines the contract every contribution must implement.
-- `@Extension` registers a **class** as a contribution to a specific extension point, identified by the contract interface's `Class<?>` literal.
+- An **extension point** is a plain Java interface that defines the contract every contribution must implement. No annotation is required.
+- A **contribution** is a `@Component` that implements that interface. Its [`@Component`](/sdk/component/decorators) name (the `value()`, or the decapitalized class name by default) is the contribution name.
 
-The runtime validates each contribution against its target interface at registration time. Consumers call [`Extensions.find(Class)`](/sdk/extensions/extensions) and receive a `List<T>` of typed instances - no reflection, no map payloads.
-
-The contract interface's fully qualified name is the persisted extension-point identifier in `DIRIGIBLE_EXTENSIONS`. Renaming or moving the interface invalidates every persisted reference, so treat the interface FQN as part of the contract.
+Contributions are discovered the same way any group of beans is: inject them all as a collection, or look them up through [`Extensions`](/sdk/extensions/extensions).
 
 ### Example Usage
 
 ```java
-import org.eclipse.dirigible.sdk.extensions.ExtensionPoint;
-import org.eclipse.dirigible.sdk.extensions.Extension;
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.component.Inject;
+import java.util.List;
 
-// 1. Declare the contract
-@ExtensionPoint("Order processors")
+// 1. The extension point - a plain interface, no annotation
 public interface OrderProcessor {
     void process(Order order);
 }
 
-// 2. Register a contribution
-@Extension(target = OrderProcessor.class, name = "fast-processor")
+// 2. A contribution - a @Component implementing the interface;
+//    its @Component name ("fast-processor") is the contribution name
+@Component("fast-processor")
 public class FastOrderProcessor implements OrderProcessor {
     public void process(Order order) {
         // ...
     }
 }
+
+// 3. Consume every contribution via collection injection (preferred)
+@Component
+public class OrderPipeline {
+
+    private final List<OrderProcessor> processors;
+
+    @Inject
+    public OrderPipeline(List<OrderProcessor> processors) {
+        this.processors = processors;
+    }
+
+    public void run(Order order) {
+        processors.forEach(p -> p.process(order));
+    }
+}
 ```
 
-## @ExtensionPoint
+## Discovering contributions
 
-Marks an interface as a typed Dirigible extension point. Apply to the **interface** that defines the contract for the contributing classes.
-
-> ```java
-> @Retention(RetentionPolicy.RUNTIME)
-> @Target(ElementType.TYPE)
-> public @interface ExtensionPoint { ... }
-> ```
-
-### Attributes
-
-| Attribute | Type | Default | Description |
-| ------ | ------ | ------ | ------ |
-| `value` | `String` | `""` | Human-readable label shown in the Extensions UI. Defaults to the interface's simple name. |
-
-## @Extension
-
-Registers the annotated class as a contribution to a typed extension point. The class must implement the `target` interface; the runtime rejects any class that does not at registration time.
-
-> ```java
-> @Retention(RetentionPolicy.RUNTIME)
-> @Target(ElementType.TYPE)
-> public @interface Extension { ... }
-> ```
-
-### Attributes
-
-| Attribute | Type | Description |
-| ------ | ------ | ------ |
-| `target` | `Class<?>` | The extension-point interface this class implements. Must carry `@ExtensionPoint`. |
-| `name` | `String` | Logical name of this contribution. Surfaced in the Extensions UI; not used for lookup. Defaults to the empty string. |
+- **Collection injection (preferred)** - inject `List<OrderProcessor>` (or `Set<…>` / `Collection<…>`) and the container supplies every `@Component` assignable to the interface. See [Component / @Inject](/sdk/component/decorators).
+- **Programmatic lookup** - call [`Extensions.find(OrderProcessor.class)`](/sdk/extensions/extensions) to get the same list, or `Extensions.findFirst(…)` for the first one. Equivalent to `Beans.getAll(…)` for the contract type.
 
 ## See also
 
-- [`Extensions`](/sdk/extensions/extensions) - typed `find(Class)` discovery.
-- Sample: [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator).
+- [`Extensions`](/sdk/extensions/extensions) - typed `find(Class)` discovery (and the legacy string-keyed `getExtensions`).
+- [Component](/sdk/component/) - `@Component` / `@Inject`, including collection injection.

--- a/docs/sdk/extensions/extensions.md
+++ b/docs/sdk/extensions/extensions.md
@@ -7,9 +7,9 @@
 - source: [extensions/Extensions.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/extensions/Extensions.java)
 :::
 
-Static facade for discovering registered contributions. The preferred entry point is the **typed** `find(Class)` / `findFirst(Class)` API - it returns instances cast to the contract interface, so callers invoke contract methods directly with no reflection.
+Static facade for discovering registered contributions. The preferred entry point is the **typed** `find(Class)` / `findFirst(Class)` API - it returns the contributions cast to the contract interface, so callers invoke contract methods directly with no reflection. `find(Class)` returns the same beans you would receive from `List<T>` injection; **prefer collection injection** in beans that can take it (see [Component / @Inject](/sdk/component/decorators)) and reach for `find` only where injection cannot.
 
-`getExtensions(String)` is the legacy string-keyed lookup retained for compatibility with `.extension` artefacts that pre-date the typed annotations. New code should use `find(Class)`.
+`getExtensions(String)` is the legacy string-keyed lookup, retained for TypeScript/JavaScript `.extension` artefacts. New Java code should use `find(Class)`.
 
 ### Key Features:
 - **Typed discovery**: `find(Class)` returns `List<T>` where `T` is the contract interface.
@@ -22,7 +22,7 @@ import org.eclipse.dirigible.sdk.extensions.Extensions;
 import java.util.List;
 import java.util.Optional;
 
-// Typed - the preferred API
+// Typed - the preferred API (same set as List<OrderProcessor> injection)
 List<OrderProcessor> processors = Extensions.find(OrderProcessor.class);
 for (OrderProcessor p : processors) {
     p.process(order);
@@ -31,7 +31,7 @@ for (OrderProcessor p : processors) {
 Optional<OrderProcessor> first = Extensions.findFirst(OrderProcessor.class);
 first.ifPresent(p -> p.process(order));
 
-// Legacy - string-keyed lookup
+// Legacy - string-keyed lookup (TypeScript/JavaScript artefacts)
 String[] modules = Extensions.getExtensions("ide-menu");
 ```
 
@@ -39,19 +39,19 @@ String[] modules = Extensions.getExtensions("ide-menu");
 
 ### find()
 
-Returns every class registered against the given extension point, instantiated and cast to the contract interface.
+Returns every contribution registered for the given extension-point interface, cast to the contract interface.
 
 > ```java
-> public static <T> List<T> find(Class<T> extensionPointType) throws Exception;
+> public static <T> List<T> find(Class<T> extensionPointType);
 > ```
 >
 > | Parameter | Type | Description |
 > | ------ | ------ | ------ |
-> | `extensionPointType` | `Class<T>` | The contract interface, marked with `@ExtensionPoint`. |
+> | `extensionPointType` | `Class<T>` | The contract interface implemented by the contributing `@Component`s. |
 >
 > ::: info Returns
 > - **Type**: `List<T>`
-> - **Description**: Every registered contribution that implements the contract.
+> - **Description**: Every registered contribution that implements the contract. Same set as `List<T>` injection.
 > :::
 
 ### findFirst()
@@ -59,7 +59,7 @@ Returns every class registered against the given extension point, instantiated a
 Returns the first registered contribution, or `Optional.empty()` if none.
 
 > ```java
-> public static <T> Optional<T> findFirst(Class<T> extensionPointType) throws Exception;
+> public static <T> Optional<T> findFirst(Class<T> extensionPointType);
 > ```
 >
 > | Parameter | Type | Description |
@@ -73,7 +73,7 @@ Returns the first registered contribution, or `Optional.empty()` if none.
 
 ### getExtensions()
 
-Legacy lookup by string-named extension point. Returns the module paths registered via `.extension` artefacts.
+Legacy lookup by string-named extension point, kept for compatibility with TypeScript/JavaScript `.extension` artefacts. Returns the module paths registered against the named point.
 
 > ```java
 > public static String[] getExtensions(String extensionPointName) throws Exception;
@@ -90,5 +90,5 @@ Legacy lookup by string-named extension point. Returns the module paths register
 
 ## See also
 
-- [`@Extension` / `@ExtensionPoint`](/sdk/extensions/decorators) - the annotations side.
-- Sample: [`dirigiblelabs/sample-java-extension-decorator`](https://github.com/dirigiblelabs/sample-java-extension-decorator).
+- [Extension model](/sdk/extensions/decorators) - plain-interface extension points and `@Component` contributions.
+- [Component](/sdk/component/) - `@Component` / `@Inject`, including collection injection.

--- a/docs/sdk/extensions/index.md
+++ b/docs/sdk/extensions/index.md
@@ -7,15 +7,13 @@
 - source: [extensions/](https://github.com/eclipse/dirigible/tree/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/extensions)
 :::
 
-This module exposes Dirigible's extension-point mechanism to Java code. Extension points are typed contracts: an interface marked with `@ExtensionPoint` defines the methods every contribution implements, and contributions marked with `@Extension(target = Contract.class, ...)` plug in.
+This module exposes Dirigible's extension-point mechanism to Java code. There is no extension annotation: an extension point is a plain Java interface, and a contribution is a [`@Component`](/sdk/component/decorators) that implements it (its `@Component` name is the contribution name).
 
-Contributions come from two sources: typed Java classes annotated with `@Extension` (preferred), or declarative `.extension` artefacts shipped in user projects (legacy). The typed API `Extensions.find(Class)` returns `List<T>` instances cast to the contract interface; the legacy `Extensions.getExtensions(String)` returns module paths by string name.
+Contributions are discovered like any group of beans - inject them all via `List<T>` (preferred), or look them up with `Extensions.find(Class)`. The legacy `Extensions.getExtensions(String)` returns module paths by string name and is kept for TypeScript/JavaScript `.extension` artefacts.
 
 The main components of this module are:
 
-- [`Extensions`](./extensions.md) - runtime discovery: `find(Class)` (typed) and `getExtensions(String)` (legacy).
-- [Decorators](./decorators.md) - the annotation pair:
-  - `@ExtensionPoint` - marks an interface as a typed extension point.
-  - `@Extension(target = ContractInterface.class)` - registers a class as a typed contribution.
+- [`Extensions`](./extensions.md) - runtime discovery: `find(Class)` / `findFirst(Class)` (typed) and `getExtensions(String)` (legacy).
+- [Extension model](./decorators.md) - plain-interface extension points and `@Component` contributions, and collection injection.
 
 ## Classes

--- a/docs/sdk/http/decorators.md
+++ b/docs/sdk/http/decorators.md
@@ -61,7 +61,7 @@ Marks a Java class as a REST controller. Methods annotated with `@Get`, `@Post`,
 
 The base URL is derived from the class's fully-qualified name (the same path used by `JavaEndpoint`): `/services/java/<project>/<package-path>/<ClassName>`. Each method annotation contributes the trailing suffix; the HTTP method comes from the annotation type.
 
-A controller class must be public, have a public no-arg constructor, and must not also implement `JavaHandler` - the two dispatch styles are mutually exclusive.
+A controller is a managed bean - it is registered like a [`@Component`](/sdk/component/decorators) and supports constructor injection (`@Inject` its collaborators), so it does **not** require a no-arg constructor. A controller class must be public and must not also implement `JavaHandler` - the two dispatch styles are mutually exclusive.
 
 ```java
 @Controller

--- a/docs/sdk/job/decorators.md
+++ b/docs/sdk/job/decorators.md
@@ -7,38 +7,61 @@
 - sources: [Scheduled.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/job/Scheduled.java), [JobHandler.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/job/JobHandler.java)
 :::
 
-`@Scheduled` registers a client Java class as a Quartz-managed scheduled job. The annotated class must expose a public no-arg `run()` method; Dirigible instantiates the class once and invokes `run()` on the configured cron schedule.
+A scheduled job is a [`@Component`](/sdk/component/decorators) declared in one of two styles - never both on the same class:
 
-The optional `JobHandler` interface formalises that `run()` shape - implementing it gives compile-time signature checking, IDE refactoring, and a direct (non-reflective) dispatch path. Classes that don't implement it still work; the runtime falls back to a reflective `run()` lookup by name.
+- **`@Scheduled`** on a method - annotate a public no-arg method of a `@Component` with `@Scheduled(expression = "<cron>")`; the runtime invokes that method on the cron schedule.
+- **`JobHandler`** - a self-describing interface (`String cron()` + `void run()`); a `@Component` that implements it *is* the job, with the cron carried by `cron()` and no `@Scheduled` needed.
 
-Hot-reload replaces the instance transparently - the old schedule is cancelled and a new one is registered with the updated class.
+Hot-reload replaces the bean transparently - the old schedule is cancelled and a new one is registered with the updated class.
 
 ### Example Usage:
+
+Method-level `@Scheduled`:
 ```java
-import org.eclipse.dirigible.sdk.job.JobHandler;
+import org.eclipse.dirigible.sdk.component.Component;
 import org.eclipse.dirigible.sdk.job.Scheduled;
 import org.eclipse.dirigible.sdk.log.Logger;
 import org.eclipse.dirigible.sdk.log.Logging;
 
-@Scheduled(expression = "0/30 * * * * ?")
-public class CleanupJob implements JobHandler {
+@Component
+public class CleanupJob {
 
     private static final Logger LOG = Logging.getLogger("com.acme.cleanup");
 
+    @Scheduled(expression = "0/30 * * * * ?")
+    public void cleanup() {
+        LOG.info("cleanup tick");
+    }
+}
+```
+
+Self-describing `JobHandler`:
+```java
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.job.JobHandler;
+
+@Component
+public class CleanupHandler implements JobHandler {
+
+    @Override
+    public String cron() {
+        return "0/30 * * * * ?";
+    }
+
     @Override
     public void run() {
-        LOG.info("cleanup tick");
+        // cleanup tick
     }
 }
 ```
 
 ## @Scheduled
 
-Registers the class as a Quartz job with the given cron expression.
+Schedules a public no-arg method of a `@Component` to run on the given cron expression. It is a **method-level** annotation.
 
 > ```java
 > @Retention(RetentionPolicy.RUNTIME)
-> @Target(ElementType.TYPE)
+> @Target(ElementType.METHOD)
 > public @interface Scheduled { ... }
 > ```
 
@@ -50,22 +73,23 @@ Registers the class as a Quartz job with the given cron expression.
 
 ### Notes
 
-- The annotated class must expose a public no-arg `run()` method. Implementing `JobHandler` is the recommended way to declare it.
+- The annotated method must be public and take no arguments.
+- The enclosing class must be a `@Component`.
 - Hot-reload reinstalls the schedule when the class changes.
 - For programmatic / non-cron scheduling, drop a `.job` JSON descriptor under the project - the Job synchronizer picks it up.
 
 ## JobHandler
 
-Optional typed contract for a `@Scheduled` class. Implementing it gives compile-time signature checking and a direct dispatch path; classes that don't implement it still work via reflection.
+Self-describing contract for a job. A `@Component` implementing it *is* the scheduled job - it carries its own cron expression, so no `@Scheduled` annotation is involved.
 
 > ```java
 > public interface JobHandler {
+>     String cron();
 >     void run();
 > }
 > ```
 
 ### Notes
 
-- `@Scheduled` is the marker that turns the class into a scheduled job - implementing the interface alone does not register anything.
-- The default dispatch path for `JobHandler` skips `Method.invoke` entirely; performance is identical to a direct call.
-- The startup log line reports which path was chosen (`typed dispatch` vs `reflective dispatch`).
+- `cron()` returns the Quartz cron expression; `run()` is the job body.
+- Use either `JobHandler` or a method-level `@Scheduled` on a class, never both.

--- a/docs/sdk/job/index.md
+++ b/docs/sdk/job/index.md
@@ -7,10 +7,11 @@
 - source: [job/](https://github.com/eclipse/dirigible/tree/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/job)
 :::
 
-This module provides the Quartz-backed scheduling surface. Job registration is **declarative** - annotate a class with `@Scheduled` and the platform manages the rest. `Scheduler` exposes a read-only listing of every Quartz job the platform knows about, useful for admin UIs.
+This module provides the Quartz-backed scheduling surface. Job registration is **declarative** - declare a [`@Component`](/sdk/component/decorators) job in either of two styles and the platform manages the rest: a method-level `@Scheduled(expression = …)`, or a class implementing the self-describing `JobHandler` interface. `Scheduler` exposes a read-only listing of every Quartz job the platform knows about, useful for admin UIs.
 
 The main components of this module are:
 - **Scheduler**: Static facade that returns the JSON list of registered jobs.
-- **@Scheduled**: Class annotation that registers a public no-arg `run()` method as a Quartz job on the given cron schedule.
+- **@Scheduled**: Method-level annotation that schedules a public no-arg method of a `@Component` on the given cron schedule.
+- **JobHandler**: Self-describing interface (`cron()` + `run()`) - a `@Component` implementing it is itself the scheduled job.
 
 ## Classes

--- a/docs/sdk/messaging/decorators.md
+++ b/docs/sdk/messaging/decorators.md
@@ -7,13 +7,12 @@
 - source: [messaging/](https://github.com/eclipse/dirigible/tree/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/messaging)
 :::
 
-The messaging module exposes three declarative types used to define always-on listeners on the embedded ActiveMQ broker:
+A message listener on the embedded ActiveMQ broker is a [`@Component`](/sdk/component/decorators) declared in one of two styles - never both on the same class:
 
-- `@Listener` - the type-level annotation that marks a Java class as a managed message listener.
-- `ListenerKind` - the enum used as the `kind` attribute of `@Listener` to choose between point-to-point queue semantics and publish-subscribe topic semantics.
-- `MessageHandler` - optional typed contract for the `onMessage` / `onError` callbacks. Implementing it gives compile-time signature checking and a direct (non-reflective) dispatch path. The legacy method-by-name reflective fallback is preserved, so classes that don't implement the interface still work unchanged.
+- **`@Listener`** on a method - annotate a public `void m(String)` method of a `@Component`; the runtime routes inbound messages from the named destination to that method.
+- **`MessageHandler`** - a self-describing interface; a `@Component` that implements it *is* the listener, carrying its destination via `destination()`.
 
-Listeners are discovered and instantiated by the Dirigible runtime at startup and on hot-reload - you do not need to register them manually.
+`ListenerKind` selects between point-to-point queue semantics and publish-subscribe topic semantics. Listeners are discovered, instantiated, and connected by the runtime at startup and on hot-reload - you do not register them manually.
 
 ## @Listener
 
@@ -21,9 +20,7 @@ Listeners are discovered and instantiated by the Dirigible runtime at startup an
 [messaging/Listener.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/messaging/Listener.java)
 :::
 
-Marks a client Java class as an ActiveMQ message listener managed by the Dirigible runtime.
-
-The annotated class must expose a public `onMessage(String message)` method and optionally an `onError(String error)` method. Dirigible instantiates the class once, connects it to the specified queue or topic, and routes incoming messages to `onMessage`. Hot-reload replaces the listener transparently - subsequent messages flow to the new instance without restart.
+Marks a public `void m(String message)` method of a `@Component` as an ActiveMQ message listener. It is a **method-level** annotation. The runtime connects the method to the specified queue or topic and invokes it for each inbound message. Hot-reload reconnects to the new instance without restart.
 
 ### Attributes:
 
@@ -34,7 +31,7 @@ The annotated class must expose a public `onMessage(String message)` method and 
 
 ### Target and retention:
 
-- `@Target(ElementType.TYPE)` - applied to classes.
+- `@Target(ElementType.METHOD)` - applied to a `void m(String)` method of a `@Component`.
 - `@Retention(RetentionPolicy.RUNTIME)` - visible to the platform's reflective scanner at runtime.
 
 ## MessageHandler
@@ -43,10 +40,12 @@ The annotated class must expose a public `onMessage(String message)` method and 
 [messaging/MessageHandler.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/messaging/MessageHandler.java)
 :::
 
-Optional typed contract for the `@Listener` callback methods. Implementing it gives compile-time signature checking and a direct dispatch path; classes that don't implement it still work via reflection.
+Self-describing contract for a listener. A `@Component` implementing it *is* the listener - it names its own destination, so no `@Listener` annotation is involved.
 
 > ```java
 > public interface MessageHandler {
+>     String destination();
+>     default ListenerKind kind() { return ListenerKind.QUEUE; }
 >     void onMessage(String message);
 >     default void onError(String error) {}
 > }
@@ -54,9 +53,9 @@ Optional typed contract for the `@Listener` callback methods. Implementing it gi
 
 ### Notes:
 
-- `@Listener` is the marker that binds the class to a destination - implementing the interface alone does not register anything.
+- `destination()` is the queue or topic name; `kind()` defaults to `QUEUE`.
 - `onError` is a default no-op so handlers that don't care about delivery failures don't need an empty stub.
-- The startup log line reports which path was chosen (`typed dispatch` vs `reflective dispatch`).
+- Use either `MessageHandler` or a method-level `@Listener` on a class, never both.
 
 ## ListenerKind
 
@@ -64,32 +63,37 @@ Optional typed contract for the `@Listener` callback methods. Implementing it gi
 [messaging/ListenerKind.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/messaging/ListenerKind.java)
 :::
 
-Destination type for a `@Listener`-annotated class. Selects between the two JMS-style delivery semantics.
+Destination type for a listener. Selects between the two JMS-style delivery semantics.
 
 ### Constants:
 
 | Constant | Description |
 | -------- | ----------- |
-| `QUEUE` | Point-to-point queue - each message is consumed by exactly one listener. The default when `kind` is omitted on `@Listener`. |
+| `QUEUE` | Point-to-point queue - each message is consumed by exactly one listener. The default when `kind` is omitted. |
 | `TOPIC` | Publish-subscribe topic - each message is delivered to all active subscribers. Use for fan-out broadcasts. |
 
 ## Example Usage
 
-A complete queue listener that processes incoming order events and logs failures:
+A queue listener via a self-describing `MessageHandler`:
 
 ```java
 package com.acme.orders;
 
-import org.eclipse.dirigible.sdk.messaging.Listener;
+import org.eclipse.dirigible.sdk.component.Component;
 import org.eclipse.dirigible.sdk.messaging.ListenerKind;
 import org.eclipse.dirigible.sdk.messaging.MessageHandler;
 import org.eclipse.dirigible.sdk.log.Logging;
 import org.eclipse.dirigible.sdk.log.Logger;
 
-@Listener(name = "orders.created", kind = ListenerKind.QUEUE)
+@Component
 public class OrderListener implements MessageHandler {
 
     private static final Logger LOG = Logging.getLogger("com.acme.orders.OrderListener");
+
+    @Override
+    public String destination() {
+        return "orders.created";
+    }
 
     @Override
     public void onMessage(String message) {
@@ -104,13 +108,18 @@ public class OrderListener implements MessageHandler {
 }
 ```
 
-A topic listener that only handles successful messages - the default `onError` no-op covers the rest:
+A topic listener via a method-level `@Listener`:
 
 ```java
-@Listener(name = "metrics.heartbeat", kind = ListenerKind.TOPIC)
-public class HeartbeatListener implements MessageHandler {
-    @Override
-    public void onMessage(String message) {
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.messaging.Listener;
+import org.eclipse.dirigible.sdk.messaging.ListenerKind;
+
+@Component
+public class HeartbeatListener {
+
+    @Listener(name = "metrics.heartbeat", kind = ListenerKind.TOPIC)
+    public void onHeartbeat(String message) {
         // every subscriber receives this message
     }
 }

--- a/docs/sdk/messaging/index.md
+++ b/docs/sdk/messaging/index.md
@@ -9,14 +9,15 @@
 
 This module is the platform messaging surface of the Eclipse Dirigible Java SDK. It exposes the embedded ActiveMQ broker that ships with every Dirigible runtime, letting Java code publish to and consume from JMS-style queues (point-to-point) and topics (publish/subscribe) without any client-side broker plumbing.
 
-Two consumption styles are supported. For long-running, always-on listeners the platform manages the consumer thread, reconnects, and dispatch - a class is marked with `@Listener`, exposes a public `onMessage(String)` method, and the runtime wires it up at startup and on hot-reload. For script-style or pull-based code that processes a single message and exits, the `Consumer` facade offers a blocking `receiveFromQueue` / `receiveFromTopic` with a millisecond timeout. Every component running on the platform - in any language - targets the same broker, so producers and listeners interoperate transparently regardless of where the message originates.
+Two consumption styles are supported. For long-running, always-on listeners the platform manages the consumer thread, reconnects, and dispatch - a [`@Component`](/sdk/component/decorators) either annotates a `void m(String)` method with `@Listener` or implements the self-describing `MessageHandler` interface, and the runtime wires it up at startup and on hot-reload. For script-style or pull-based code that processes a single message and exits, the `Consumer` facade offers a blocking `receiveFromQueue` / `receiveFromTopic` with a millisecond timeout. Every component running on the platform - in any language - targets the same broker, so producers and listeners interoperate transparently regardless of where the message originates.
 
 The main components of this module are:
 
 - [`Producer`](./producer.md) - sends a message to a queue or topic on the embedded ActiveMQ broker.
 - [`Consumer`](./consumer.md) - synchronously pulls a single message from a queue or topic with a millisecond timeout.
-- [Decorators](./decorators.md) - annotation set used to declare always-on listeners:
-  - `@Listener` - marks a class as an ActiveMQ message listener
-  - `ListenerKind` - enum selecting `QUEUE` or `TOPIC` semantics for the annotated listener
+- [Decorators](./decorators.md) - used to declare always-on listeners:
+  - `@Listener` - method-level annotation marking a `void m(String)` method of a `@Component` as a listener
+  - `MessageHandler` - self-describing interface; a `@Component` implementing it is itself the listener
+  - `ListenerKind` - enum selecting `QUEUE` or `TOPIC` semantics for the listener
 
 ## Classes

--- a/docs/sdk/net/decorators.md
+++ b/docs/sdk/net/decorators.md
@@ -7,24 +7,32 @@
 - sources: [Websocket.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/net/Websocket.java), [WebsocketHandler.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/net/WebsocketHandler.java)
 :::
 
-`@Websocket` marks a client Java class as a WebSocket handler managed by the Dirigible runtime. The annotated class may expose any combination of:
+A WebSocket handler is a [`@Component`](/sdk/component/decorators) declared in one of two styles - never both on the same class:
+
+- **`@Websocket` + `@OnX`** - mark the class with `@Websocket(name = …, endpoint = …)` and annotate its lifecycle methods with `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose`.
+- **`WebsocketHandler`** - a self-describing interface; a `@Component` that implements it *is* the handler, carrying its endpoint via `endpoint()` and overriding only the lifecycle defaults it needs.
+
+The lifecycle callbacks are:
 
 - `onOpen()` - called when a client connects
-- `onMessage(String message, String from)` - called for each inbound message
+- `onMessage(String message, String from)` - called for each inbound message; a non-`void` return value is sent back to the client
 - `onError(String error)` - called on transport or handler error
 - `onClose()` - called when the connection is closed
 
-All methods are optional; missing ones are silently skipped.
-
-The optional `WebsocketHandler` interface formalises the four callback shapes. Implementing it gives compile-time signature checking and lets each lifecycle method be omitted - the interface provides empty default implementations, so a handler that only cares about `onMessage` doesn't have to declare empty stubs for the rest. Classes that don't implement the interface still work via the same method-by-name reflective dispatch as before.
-
 ### Example Usage:
+
+Self-describing `WebsocketHandler`:
 ```java
-import org.eclipse.dirigible.sdk.net.Websocket;
+import org.eclipse.dirigible.sdk.component.Component;
 import org.eclipse.dirigible.sdk.net.WebsocketHandler;
 
-@Websocket(name = "chat", endpoint = "chat")
+@Component
 public class ChatHandler implements WebsocketHandler {
+
+    @Override
+    public String endpoint() {
+        return "chat";
+    }
 
     @Override
     public void onMessage(String message, String from) {
@@ -35,11 +43,28 @@ public class ChatHandler implements WebsocketHandler {
 }
 ```
 
+Annotation style with `@Websocket` + `@OnX`:
+```java
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.net.Websocket;
+import org.eclipse.dirigible.sdk.net.OnMessage;
+
+@Component
+@Websocket(name = "chat", endpoint = "chat")
+public class ChatController {
+
+    @OnMessage
+    public String onMessage(String message, String from) {
+        return "echo: " + message; // returned value is sent back to the client
+    }
+}
+```
+
 The example handler is reachable by clients via the URL suffix `/websockets/stomp/chat`.
 
 ## @Websocket
 
-Registers the class as a STOMP WebSocket handler.
+Marks the `@Component` class as a STOMP WebSocket handler, paired with method-level `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose`.
 
 > ```java
 > @Retention(RetentionPolicy.RUNTIME)
@@ -54,12 +79,30 @@ Registers the class as a STOMP WebSocket handler.
 | `name` | `String` | Logical display name for the websocket. |
 | `endpoint` | `String` | URL endpoint suffix used by the client to connect - for example, `"chat"` maps to `/websockets/stomp/chat`. |
 
+## @OnOpen / @OnMessage / @OnError / @OnClose
+
+Method-level annotations that bind the WebSocket lifecycle events on a `@Websocket` class.
+
+> ```java
+> @Retention(RetentionPolicy.RUNTIME)
+> @Target(ElementType.METHOD)
+> public @interface OnOpen { }
+> // ... OnMessage, OnError, OnClose follow the same shape
+> ```
+
+### Notes:
+
+- `@OnMessage` binds a `(String message, String from)` method; a non-`void` return is sent back to the client.
+- `@OnOpen` / `@OnClose` bind no-arg methods; `@OnError` binds a `(String error)` method.
+- Every callback is optional - annotate only the events you need.
+
 ## WebsocketHandler
 
-Optional typed contract for `@Websocket` lifecycle callbacks. All four methods are `default` and no-op, so implementations only override what they need.
+Self-describing contract for a WebSocket handler. A `@Component` implementing it *is* the handler - it names its own endpoint and overrides only the lifecycle methods it needs (all are `default` no-ops).
 
 > ```java
 > public interface WebsocketHandler {
+>     String endpoint();
 >     default void onOpen()                                {}
 >     default void onMessage(String message, String from)  {}
 >     default void onError(String error)                   {}
@@ -69,6 +112,6 @@ Optional typed contract for `@Websocket` lifecycle callbacks. All four methods a
 
 ### Notes:
 
-- `@Websocket` is the marker that registers the class for an endpoint - implementing the interface alone does not register anything.
-- Every callback has an empty default, so partial implementations are explicit by design - omit anything you don't need.
-- The reflective fallback finds the same `onOpen` / `onMessage(String, String)` / `onError(String)` / `onClose` methods by name on classes that don't implement the interface.
+- `endpoint()` is the URL endpoint suffix (e.g. `"chat"` → `/websockets/stomp/chat`).
+- Every lifecycle callback has an empty default, so partial implementations are explicit by design - omit anything you don't need.
+- Use either `WebsocketHandler` or `@Websocket` + `@OnX` on a class, never both.

--- a/docs/sdk/net/index.md
+++ b/docs/sdk/net/index.md
@@ -7,11 +7,11 @@
 - source: [net/](https://github.com/eclipse/dirigible/tree/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/net)
 :::
 
-This module exposes minimal helpers for SOAP traffic and STOMP WebSockets, plus the `@Websocket` annotation that turns a client class into an inbound WebSocket handler.
+This module exposes minimal helpers for SOAP traffic and STOMP WebSockets, plus the decorators that turn a [`@Component`](/sdk/component/decorators) into an inbound WebSocket handler.
 
 The main components of this module are:
 - **Soap**: Static helpers built directly on `jakarta.xml.soap` - create / parse / invoke SOAP messages.
 - **Websockets**: Static facade for outbound STOMP WebSocket clients and inspecting active connections.
-- **@Websocket**: Class annotation that marks a Java class as an inbound WebSocket handler managed by the runtime.
+- **Decorators**: `@Websocket` + method-level `@OnOpen` / `@OnMessage` / `@OnError` / `@OnClose`, or the self-describing `WebsocketHandler` interface - either turns a `@Component` into an inbound WebSocket handler.
 
 ## Classes


### PR DESCRIPTION
## Summary

Updates the **Develop** guide and the **Java SDK reference** to the Spring-style client-Java model introduced in eclipse-dirigible/dirigible#6051, and reorganizes the affected pages so a reader instantly finds the language they want.

## New: "Coming from Spring Boot"

A new `docs/help/develop/coming-from-spring-boot.md` (linked from the Develop sidebar) for developers who already know Spring:

- A **Spring/Jakarta → Dirigible mapping table** (`@Component`, `@Autowired`→`@Inject`, `ApplicationContext`→`Beans`, `@RestController`→`@Controller`, Spring Data→`JavaRepository`, `@Scheduled`/`@JmsListener`, `TextWebSocketHandler`/`@ServerEndpoint`, `@RolesAllowed`→`@Roles`, lifecycle).
- A **"Side-by-side: implementing each artifact"** section that shows the **Spring example first, then the Dirigible one** for Listener, Job, WebSocket, Controller, Repository and Extension — both the self-describing-interface and method-level styles — so the similarity is obvious. **Every snippet (both Spring and Dirigible) is fully imported and copy-paste-ready.**

## Develop pages — current model + per-language split

- **dependency-injection** — `@Component`, constructor / field / collection injection, `Beans`; the "How it is wired" section is kept implementation-agnostic (behavioural guarantees only, no internal class names) so it won't go stale.
- **scheduled-jobs / message-listeners / websockets** — the two clean styles (self-describing interface vs method-level annotation); reflective/hybrid wording removed; real examples linked to the matching sample repos.
- **extension-providers** — rewritten to the annotation-free model (plain interface + `@Component` contribution + `List<…>` collection injection / `Extensions.find`); the "Consume at runtime" section split into clear Java vs TypeScript/JavaScript subsections.
- **rest-apis** and **entities-and-persistence** — the former "side by side" code blocks are now separate `### Java` / `### TypeScript / JavaScript` subsections (Java first); constructor injection shown.
- **security-and-roles**, **working-with-data**, **working-with-files-and-cms**, **working-with-git** — `@Roles`, the Java `User` API, and the IO/CMS/Git examples split per language; the tenancy/multi-tenancy sections removed from entities-and-persistence, working-with-data and working-with-files-and-cms.
- **decorators-model**, **languages/java**, **develop/index** — corrected the stale "`@Scheduled`/`@Listener`/`@Extension` are meta-`@Component`" claim and dropped removed `@Extension`/`@ExtensionPoint` references.

## SDK reference (`/sdk`)

- **component** — `@Component`, `@Inject` (field/constructor/parameter + collection), `@Repository` as a bean; new **Beans** page wired into the sidebar.
- **job / messaging / net** — self-describing `JobHandler`/`MessageHandler`/`WebsocketHandler`; method-level `@Scheduled`/`@Listener`; new `@OnOpen`/`@OnMessage`/`@OnError`/`@OnClose`; reflective/class-level wording removed.
- **extensions** — annotation-free model; `Extensions.find`/`getExtensions` clarified.
- **db/store**, **http/decorators**, get-started — `Beans` instead of `BeanProvider` for client access; `@Controller` is a bean (constructor injection).

## Other help & blog pages

Swept `docs/help/**` and the 2026-05-19 Java-decorators blog so they no longer present the removed/old API (no client-facing `BeanProvider`, no `@Extension`/`@ExtensionPoint`, no `@Scheduled(cron=…)` for Dirigible, no removed internal class names). TypeScript/JavaScript content and the classic registry artefacts (`.job`, `.listener`, `.extension`, …) are unchanged.

Documents eclipse-dirigible/dirigible#6051 — **merge after** it (and after the sample PRs the examples reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
