### PR TITLE
Document the Intent feature (Help section + cross-links)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -196,6 +196,18 @@ function helpSidebar() {
       ],
     },
     {
+      text: 'Intent',
+      collapsed: true,
+      items: [
+        { text: 'Overview', link: '/help/intent/' },
+        { text: 'The .intent file', link: '/help/intent/intent-file' },
+        { text: 'The Intent Editor', link: '/help/intent/editor' },
+        { text: 'The AI assistant', link: '/help/intent/ai-assistant' },
+        { text: 'Generators and generation', link: '/help/intent/generators' },
+        { text: 'Declarative glue', link: '/help/intent/glue' },
+      ],
+    },
+    {
       text: 'IDE',
       collapsed: true,
       items: [

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -11,6 +11,7 @@ Welcome to the **Eclipse Dirigible** documentation. Dirigible is a high-producti
 
 - **[Get Started](/help/get-started/)** - install Dirigible, log in, and build your first endpoint.
 - **[Concepts](/help/concepts/)** - read these once; everything else makes more sense afterwards.
+- **[Intent](/help/intent/)** - author an entire application from one `.intent` file, with an AI assistant. The [Intent-Driven Application Development](/manifesto/) layer.
 - **[IDE](/help/ide/)** - the in-browser workbench, perspectives, editors, and modelers.
 - **[Develop](/help/develop/)** - building applications with the decorator-driven model.
 - **[Artefacts](/help/artefacts/)** - every file extension and what the platform does with it.

--- a/docs/help/intent/ai-assistant.md
+++ b/docs/help/intent/ai-assistant.md
@@ -1,0 +1,51 @@
+---
+title: The AI assistant
+description: The Intent Editor's third pane - Claude proposes a complete updated app.intent through a tool, the editor shows it as a diff, and Accept merges it. The key stays server-side.
+---
+
+# The AI assistant
+
+The third pane of the [Intent Editor](/help/intent/editor) (toggled by the toolbar's discussion icon) is a natural-language assistant that edits `app.intent` at your altitude. It **proposes a patch to the intent, never a re-emitted model file** - the "edit shape, not file shape" contract from the [manifesto](/manifesto/).
+
+It is optional. Turn it off and the editor is still a structured YAML editor a person drives directly. AI is an accelerator, never a single point of failure.
+
+## How it works
+
+1. You describe a change in plain language ("add a country field to Customer").
+2. The browser sends `{ yaml, message, history }` to `POST /services/ide/intent/agent`.
+3. The server calls the Anthropic Messages API and returns `{ reply, proposedYaml }`. Claude answers either with a plain-text clarifying question, or by calling a single `propose_intent` tool that returns the **complete** updated YAML.
+4. The editor renders the proposal as a Monaco **diff** against the current buffer.
+5. **Accept** replaces the buffer (still unsaved - dirty tracking and the debounced re-parse fire as usual). **Reject** discards it.
+
+You still Save and Generate yourself. **The assistant never writes to disk and never runs the generators.**
+
+Returning the whole file and diffing it locally was chosen over LLM-authored unified diffs (fragile to apply) and structured edit-ops (which lose comments and formatting). The system prompt teaches Claude the diff-stability rules: change minimally, preserve key order and comments, append rather than reorder.
+
+## The system prompt
+
+The assistant's system prompt is an **externalised, reviewable resource** (`intent-assistant-guide.md`, loaded from the classpath), not an inline string - so it can be maintained as documentation and kept in lockstep with what the parser enforces. It documents the full schema, including the [declarative-glue catalog](/help/intent/glue) and the trigger `businessKey` / `businessKeyStrategy`, plus the recipient grammar (literal / direct field / one-hop `relation.field`, no braces).
+
+## Transcript discipline
+
+The browser keeps two lists: a display log (which may hold errors and UI notes) and a clean alternating user/assistant transcript sent as `history`. The current YAML is embedded fresh in every latest user turn, so the model always diffs against ground truth even after an Accept. Tool calls are not replayed. A failed turn pops its dangling user turn so the next request stays alternating.
+
+## Configuration
+
+The API key is read server-side via `DirigibleConfig` and is **never** sent to the browser. With no key configured the assistant is disabled and the endpoint returns `412`.
+
+| Environment variable | Default | Purpose |
+| --- | --- | --- |
+| `DIRIGIBLE_INTENT_AI_API_KEY` | (blank) | Anthropic API key. Blank disables the assistant. |
+| `DIRIGIBLE_INTENT_AI_MODEL` | `claude-opus-4-8` | model id |
+| `DIRIGIBLE_INTENT_AI_BASE_URL` | `https://api.anthropic.com` | API base URL |
+| `DIRIGIBLE_INTENT_AI_MAX_TOKENS` | `8192` | max response tokens |
+| `DIRIGIBLE_INTENT_AI_VERSION` | `2023-06-01` | Anthropic API version header |
+
+The whole feature is one server-side bridge (`IntentAgentService` + `IntentAgentEndpoint`); the JDK `HttpClient` makes the call. The key never leaves the server.
+
+## See also
+
+- [The Intent Editor](/help/intent/editor)
+- [The `.intent` file](/help/intent/intent-file)
+- [Intent-Driven Application Development Manifesto](/manifesto/)
+- [Environment variables](/help/setup/environment-variables)

--- a/docs/help/intent/editor.md
+++ b/docs/help/intent/editor.md
@@ -1,0 +1,61 @@
+---
+title: The Intent Editor
+description: A split editor - Monaco YAML on the left, a live mxGraph diagram on the right, inline validation, and Generate - opened by double-clicking any .intent file.
+---
+
+# The Intent Editor
+
+Double-click any `.intent` file to open it. The editor is registered for content type `application/yaml+intent` via the `platform-editors` extension point, like every other specialised editor.
+
+## Layout
+
+A three-pane split:
+
+- **Source (left)** - an embedded Monaco editor with YAML highlighting, theme-synced to the IDE. Save with the toolbar button or `ctrl+s`; dirty state is tracked. The text buffer is the single source the parse / diagram / Generate code reads.
+- **Diagram (right)** - a live, read-only [mxGraph](/help/ide/modelers/) rendering of the intent, refreshed on a 600ms debounce as you type.
+- **AI assistant (toggled)** - a third pane behind the toolbar's discussion icon. See [the AI assistant](/help/intent/ai-assistant).
+
+Below the diagram, the forms / reports / roles / seeds are summarised as plain bound HTML.
+
+## The diagram
+
+`POST /services/ide/intent/parse` is called on every debounced change; the response drives both the diagram and the validation strip. The diagram has these sections:
+
+- **Entities** - one card per entity (name over its field list, PK marked), laid out left-to-right. A solid edge is a required relation, a dashed edge an optional one.
+- **One flowchart per process** - slate start/end ellipses, blue user-task and green service-task rounded rectangles, an amber decision rhombus. A decision emits a conditioned edge (`if`) to `then` and a default edge to `else`, exactly as the generated BPMN does.
+- **Glue and Outputs** - one card per form / report / notification / schedule / integration / inbound webhook / rollup, each badged with a platform icon and edged to the entity it binds to.
+
+The cells use **fixed brand colours** chosen to read on both the light and dark IDE themes, painted on a transparent canvas. The diagram therefore looks identical in either theme and does not recolour on a theme switch. It is read-only: there is no selection or editing. Authoring is the YAML pane plus the AI assistant - the diagram confirms, it does not capture.
+
+## Validation
+
+Structural problems surface inline as a strip fed by the `/parse` call. The parser reports **every** issue at once, not just the first:
+
+- duplicate entity / process / form / report / seed names;
+- dangling relation / form / report / seed targets;
+- unknown field types, relation kinds, step kinds;
+- decision `then` / `else` targets that name no declared step;
+- multiple primary keys, a non-integer PK, empty seeds;
+- a wrong-typed scalar (for example an unquoted-brace recipient) reported as a clean issue rather than a 500.
+
+Nothing is persisted by `/parse`; it only validates and feeds the views.
+
+## Generate
+
+The **Generate** button calls `POST /services/ide/intent/generate`, which:
+
+1. resolves your workspace project (so it is inherently user-scoped);
+2. reads the intent file and runs every registered generator (a failure in one is logged and isolated);
+3. scrubs stale intent-owned model files at the project root;
+4. returns `{ "written": [...], "scrubbed": [...] }` and a code-generation plan.
+
+The project tree is then refreshed (the same `projects.tree.refresh` mechanism the form builder uses), so the generated model files appear immediately. Generation is **idempotent and diff-stable**: identical input produces byte-identical output, and byte-identical content is not rewritten. See [Generators and generation](/help/intent/generators) for the regeneration contract.
+
+The editor can chain the second level too - replaying the code-generation plan turns the generated models into the full-stack application under `gen/`.
+
+## See also
+
+- [The `.intent` file](/help/intent/intent-file)
+- [The AI assistant](/help/intent/ai-assistant)
+- [Generators and generation](/help/intent/generators)
+- [Editors overview](/help/ide/editors/)

--- a/docs/help/intent/generators.md
+++ b/docs/help/intent/generators.md
@@ -1,0 +1,77 @@
+---
+title: Generators and generation
+description: The six model generators that turn an .intent into .edm / .bpmn / .form / .report / .roles / .csvim, the regeneration and scrub contract, and the .settings recipe.
+---
+
+# Generators and generation
+
+Generate runs every registered generator in `@Order`, writes the derived model files at the project root, then scrubs any stale intent-owned files. Each generator is a Spring bean implementing one slice; ordering leaves gaps of 100 so future generators can slot between.
+
+## What each generator produces
+
+| Intent block | Output | Order |
+| --- | --- | --- |
+| `entities` | `<intent>.edm` (XML) + `<intent>.model` (JSON twin) | 200 |
+| `processes[]` | `<process>.bpmn` (one per process) | 300 |
+| `forms[]` | `<form>.form` (one per form) | 400 |
+| `reports[]` | `<report>.report` (one per report) | 500 |
+| `permissions` | `<intent>.roles` | 600 |
+| `seeds[]` | `<seed>.csvim` + `<seed>.csv` (one pair per seed) | 700 |
+| triggers, resolvers, glue | `<intent>.glue` | (with the events template) |
+
+These cover every intent block defined today.
+
+### Entities to `.edm` + `.model`
+
+`EdmIntentGenerator` writes a complete, openable EDM document plus its JSON twin. It fleshes each entity out with EDM editor defaults (icons, menu keys, layout type, perspective metadata, widget types) derived from the names, so the model opens correctly in the [Entity Data modeler](/help/ide/modelers/entity-data). It follows the canonical Dirigible conventions:
+
+- property names are PascalCase; physical columns stay UPPER_SNAKE and intent-prefixed;
+- every property carries `auditType="NONE"`; required fields and FKs carry `isRequiredProperty="true"` (the REST controller's required-value validation keys on it);
+- **every to-one FK property carries full relationship metadata** - `relationshipType` (COMPOSITION vs ASSOCIATION), `relationshipCardinality` (`1_n` / `n_1` / `1_1`), `relationshipName` (`<owner>_<target>`), `relationshipEntityName`, `relationshipEntityPerspectiveName`. The last two build the FK dropdown's data-service URL, so they are not optional;
+- the `.edm` also carries an `mxGraphModel` diagram block - the EDM editor renders its canvas exclusively from this, so without it the editor opens empty.
+
+### Processes to `.bpmn`
+
+`BpmnIntentGenerator` writes minimal Flowable BPMN 2.0: a start event, the steps, an end event, the connecting flows, and an exclusive gateway per decision. It emits the `bpmndi:BPMNDiagram` interchange block (a deterministic left-to-right layout) so the BPMN modeler renders a canvas - a process with no shapes opens empty. Element ids are lower camelCase; task / gateway / process display names are humanized (`librarianReview` to "Librarian Review").
+
+### Forms, reports, roles, seeds
+
+- `FormIntentGenerator` to `<form>.form` - typed controls bound to the entity, action buttons coloured by name.
+- `ReportIntentGenerator` to `<report>.report` - the Dirigible `.report` shape with a materialised SQL `query` (joins from `relation.field` paths, `WHERE` from `filter`, default-role `security`). All physical identifiers double-quoted for Postgres.
+- `PermissionIntentGenerator` to `<intent>.roles` - deduped roles; no `.access` URL constraints (those belong to the downstream template).
+- `CsvimIntentGenerator` to `<seed>.csvim` + `<seed>.csv` - platform-default CSVIM settings; project-qualified CSV path.
+
+See [the `.intent` file](/help/intent/intent-file) for the authoring shape each consumes, and [declarative glue](/help/intent/glue) for the `.glue` output.
+
+## The regeneration contract
+
+This is the most important operational rule of the intent layer:
+
+- Generators write **only** through the generation context's `writeModelFile`, **only at the project root**. A generator that writes elsewhere would have its output scrubbed right after producing it.
+- After the pass, **stale intent-owned model files at the project root are deleted** - any model-layer file the pass did not re-emit. Remove a process / form / seed from the intent and its model file disappears on the next Generate. The scrub is limited to model extensions and direct child resources; it never touches `app.intent` itself, code files, `gen/`, or `custom/`.
+- **Never write into `gen/`.** The model-to-code templates own that folder and wipe it wholesale on every regeneration; intent output placed there would be destroyed.
+- Generators **never reference template-engine output paths** - the intent layer is ignorant of which downstream template will consume its models, so it cannot couple to one template's choices.
+- Generation is **idempotent and diff-stable**: identical input produces byte-identical output; byte-identical content is not rewritten.
+
+Output extensions are restricted to the model layer: `.edm` / `.model` / `.bpmn` / `.form` / `.report` / `.roles` / `.access` / `.glue` / `.dsm` / `.schema` / `.table` / `.view` / `.csvim` / `.csv`. Anything code-shaped (`*.ts`, `*.java`, `*.html`, `*.sql`, `*.css`) is the template engine's output and is never emitted by an intent generator. The one exception is the declarative-glue layer, which deliberately generates annotated client-Java - see [glue](/help/intent/glue).
+
+## The `.settings` file
+
+`<intent>.settings` is **developer-owned**: scaffolded once on the first Generate, then preserved (never scrubbed). It holds:
+
+- the **generation recipe** - which template id and parameters to use per model type when chaining model-to-code;
+- per-artefact **overrides** (`{ triggers | resolvers | forms }.<name>.generate = false`) - skip a generated artefact and reuse a hand-written one under `custom/`;
+- `userTasks.candidateGroupsExtra` (defaults to `ADMINISTRATOR`, appended to every user-task `candidateGroups`).
+
+It is loaded before the generators run and honoured by the glue, form and BPMN generators. The Generate endpoint returns a code-generation plan built from this recipe plus the written files, which the editor replays to chain model-to-code.
+
+## From models to the application
+
+The intent stops at the model file. To get the running application, the model is fed to the platform's existing **"Generate from EDM / Schema / BPMN"** templates - the same [generation from models](/help/develop/using-templates-for-generation) that classic projects use - producing the schema, persistence, REST services, UI, jobs and listeners under `gen/`. The editor can chain this step from its Generate button; otherwise open a generated model and run the template engine there.
+
+## See also
+
+- [The `.intent` file](/help/intent/intent-file)
+- [Declarative glue](/help/intent/glue)
+- [Generation from models](/help/develop/using-templates-for-generation)
+- [The synchronizer model](/help/concepts/synchronizer-model)

--- a/docs/help/intent/glue.md
+++ b/docs/help/intent/glue.md
@@ -1,0 +1,139 @@
+---
+title: Declarative glue
+description: notifications, schedules, integrations, inbound webhooks, rollups and lifecycle triggers - declared in the intent, generated as annotated client-Java, no hand-written code.
+---
+
+# Declarative glue
+
+Beyond the model artefacts, the intent declares **glue**: common integrations and activities that would otherwise be hand-written code. The abstraction is one line:
+
+> glue = `on <event>` then `do <action>`, with action parameters bound by resolver paths.
+
+Three axes:
+
+- **Event** - an entity `onCreate` / `onUpdate` / `onDelete` (with an optional `when:` guard), a schedule (`cron`), or an inbound webhook.
+- **Action** - notify (email), call out (HTTP), ingest into an entity, recompute a counter, start a process.
+- **Binding** - the **resolver path grammar** (`customer.name`, `member.email`): one-hop relation walks off the triggering entity, validated at parse time exactly like a decision's `then` / `else`.
+
+## Glue is generated annotated client-Java
+
+Unlike the model generators (which emit `.edm` / `.bpmn` / `.form` / ...), each glue activity is generated as an **annotated client-Java class against the SDK** (`org.eclipse.dirigible.sdk.*`) under `gen/events` - `@Listener` + `MessageHandler`, `@Scheduled` + `JobHandler`, `@Controller` + `@Post`. The annotated class **is** the artefact: `engine-java` synchronises and runs it, it is deterministic and regenerated with the app, and it is replaceable via a `custom/` override.
+
+This is a deliberate exception to "never emit code from a generator" - because client-Java is now the platform's primary runtime and TypeScript is being deprecated. The line still held: **no hand-written business logic in `gen/`.** The moment an action needs real logic it becomes a `script` step or a `custom/` hook, never more intent syntax.
+
+The author-facing fields are translated to Java by shared support classes (`EventBinding`, `NotificationSupport`, `ScheduleSupport`, the typed `Criteria` query API), emitted into `<intent>.glue`, and rendered by the `template-application-events-java` templates. `gen/events` is a sibling of `gen/<model>`, so it survives the per-model regeneration wipe.
+
+::: warning Event-key gotcha
+An event-binding key is `event:`, never `on:` - YAML 1.1 resolves a bare `on` (also `off` / `yes` / `no`) to the boolean `true`, so an `on:` key is silently swallowed. An action key is `do:`.
+:::
+
+## notifications
+
+Email on an entity lifecycle event.
+
+```yaml
+notifications:
+  - name: orderUpdated
+    event: { onUpdate: Order }
+    channel: email
+    to: ops@example.com
+    subject: "Order {id} for {customer.name}, total {total}"
+    body: "The order changed."
+```
+
+Generates a `gen/events/<Name>Notification.java` `@Listener` using `sdk.mail.Mail`, bound to the entity's create / `-updated` / `-deleted` topic. `to` and `{placeholder}` resolve a literal, a direct field, or a **one-hop `relation.field`** of a to-one relation (the listener loads the related entity once by FK id). `when:` supports a single `field ==|!= literal` guard. Multi-hop paths (`a.b.c`) are the remaining gap; the parser rejects them with a clear message.
+
+## schedules
+
+Cron reminders / cleanups - query an entity and act per matching row.
+
+```yaml
+schedules:
+  - name: staleOrders
+    cron: "0 0 9 * * ?"
+    entity: Order
+    where:
+      - { field: orderDate, op: lt, value: CURRENT_DATE }   # eq/ne/gt/ge/lt/le/like
+    notify:
+      to: ops@example.com
+      subject: "Stale order {id} for {customer.name}"
+      body: "This order is stale."
+```
+
+Generates a `gen/events/<Name>Job.java` `@Scheduled` `JobHandler` that runs a typed `Criteria` query (`where` to typed conditions, `CURRENT_DATE` / `CURRENT_TIMESTAMP` to now) and performs the per-row `notify` (same relation-load + interpolation as notifications). The action is `notify` only for now.
+
+## integrations
+
+Tell another system on an event (outbound HTTP).
+
+```yaml
+integrations:
+  - name: pushOrderToWarehouse
+    event: { onCreate: Order }
+    method: POST
+    url: "@config:WAREHOUSE_URL"
+```
+
+Generates a `gen/events/<Name>Integration.java` `@Listener` that forwards the entity-event JSON to the URL via `sdk.http.HttpClient`. The `@config:KEY` sugar resolves to `Configurations.get` so endpoints and secrets stay out of the source. The body forwards the whole entity for now (custom body mapping and headers are later).
+
+## inbound
+
+Another system tells us - a webhook that ingests a JSON payload into an entity.
+
+```yaml
+inbound:
+  - name: ingestOrder
+    path: /ingest
+    create: Order
+```
+
+Generates a `gen/events/<Name>Webhook.java` `@Controller` with a `@Post("<path>")` that deserialises the body into the entity and saves it, returning the saved JSON. Served at `/services/java/<project>/gen/events/<Name>Webhook<path>`. The v1 action is `create` (ingest).
+
+## rollups
+
+Maintain a denormalized counter on a parent.
+
+```yaml
+rollups:
+  - name: customerOrderCount
+    entity: Order        # the child being counted
+    via: customer        # the to-one relation up to the parent
+    field: orderCount     # the parent field to write
+```
+
+Generates two `gen/events/<Name>RollupOn{Create,Delete}.java` `@Listener`s on the child's create / delete topics that recompute the affected parent's count via a typed `Criteria` and write it back. Recompute-on-event (self-healing), so it is **eventually consistent, not transactionally exact** under heavy concurrency. It counts all children (no `where` filter yet) and tracks create / delete only (not re-parenting on update).
+
+## Lifecycle triggers
+
+A process `trigger` (start a process on an entity event) is the original glue and is documented with [processes](/help/intent/intent-file#processes), including the configurable `businessKey` and `businessKeyStrategy: timestamp`. Decision **resolvers** (load a related entity's field at a gateway) are also glue, emitted into `<intent>.glue`.
+
+## What one intent can declare today
+
+| Glue | Status |
+| --- | --- |
+| Lifecycle triggers (process start, `when` guard, business key + timestamp strategy) | implemented |
+| Decision resolvers (`relation.field` at a gateway) | implemented |
+| Notifications (email; literal / field / one-hop relation; `when`) | implemented |
+| Schedules (cron to typed-`Criteria` query to per-row notify) | implemented |
+| Integrations (event to `HttpClient`) | implemented |
+| Inbound webhooks (`@Controller` ingest to entity) | implemented |
+| Rollups (recompute a parent counter) | implemented |
+| Documents (PDF) | planned |
+| Status lifecycle / state machine | planned |
+| Audit / history | planned |
+| Dynamic user-task assignment | planned |
+
+## Guardrails
+
+- **Curated vocabulary, not a DSL.** Real logic is a `script` step or a `custom/` hook - the escape hatch is non-negotiable.
+- **Every generated glue artefact has an override switch** via `.settings` (`overrides.{...}.generate = false`), so a hand-written `custom/` class can replace any single generated one.
+- **Secrets and endpoints via `@config:` / `Configurations`**, never inline.
+- **Bindings validated at parse** - a dangling `customer.namez` fails fast, not at runtime.
+- Determinism, diff stability and comment preservation, as for every generator; each generated class carries a "generated from intent - do not edit" header.
+
+## See also
+
+- [The `.intent` file](/help/intent/intent-file)
+- [Generators and generation](/help/intent/generators)
+- [Message listeners](/help/develop/message-listeners) and [scheduled jobs](/help/develop/scheduled-jobs) - the SDK surfaces the glue generates against
+- [Java SDK](/sdk/)

--- a/docs/help/intent/index.md
+++ b/docs/help/intent/index.md
@@ -1,0 +1,76 @@
+---
+title: Intent
+description: One .intent file at a project root authors every other model in the project - entities, processes, forms, reports, roles, seeds - one altitude above the EDM / BPMN / form layer.
+---
+
+# Intent
+
+A single `.intent` file at a project root is the source of truth for every other authoring artefact in that project. The intent layer sits **one altitude above** the models Dirigible already generates from: where you used to hand-author `.edm` / `.bpmn` / `.form` / `.report` / `.roles` / `.csvim` and generate code from them, the intent layer authors **those model files themselves** from one YAML document.
+
+This is the practical, feature-level documentation. For the philosophy behind it - why Model-Driven Development needed a new authoring layer - read the [Intent-Driven Application Development Manifesto](/manifesto/).
+
+## The three altitudes
+
+| Altitude | Artefact | Authored by | Transform below it |
+| --- | --- | --- | --- |
+| 1 - Intent | `app.intent` (one per project) | human + AI, in the Intent Editor | deterministic generation |
+| 2 - Models | `.edm` / `.model` / `.bpmn` / `.form` / `.report` / `.roles` / `.glue` / `.csvim` | the intent generators | the existing template engine |
+| 3 - Application | schema, persistence, REST, UI, jobs, listeners, processes, security | the platform's `template-application-*` templates | the [synchronizers](/help/concepts/synchronizer-model) bring it live |
+
+The intent **never emits code**. It stops at the model file. `Entity.ts`, `Controller.ts`, `*.java`, HTML and SQL come from the IDE's existing "Generate from EDM / Schema / BPMN" templates, fed by the model files the intent wrote. That contract is non-negotiable.
+
+## Editor-first, not a synchronizer
+
+The intent is an **authoring** artefact, not a runtime one. The platform draws a hard line: authoring artefacts (`.edm`, `.form`, `.report`, `.intent`) get **editors in the workspace plus an explicit Generate step**; only runtime artefacts (`.bpmn`, `.roles`, `.csvim`, jobs, listeners) are reconciled from the registry by synchronizers. The `.edm` has no synchronizer - and neither does the intent.
+
+Consequences:
+
+- Generation happens **in your workspace project**, visible immediately in the Projects view, before anything is published.
+- A published `app.intent` is inert source (exactly like a published `.edm`). The generated models are committed and published as artefacts; an intent-only project does not self-materialise from a headless git import.
+- There is no `DIRIGIBLE_INTENTS` table, no JPA entity, no `IntentSynchronizer`.
+
+## The workflow
+
+```
+1. Create a project in your workspace.
+2. Create app.intent (any *.intent) at the project root - by hand, via the structured editor, or by prompting the AI assistant.
+3. Double-click it. The Intent Editor opens: editable YAML on the left, a live read-only diagram on the right, validation issues inline.
+4. Click Generate. The generators write the derived model files NEXT TO app.intent, in your workspace project:
+       <intent>.edm + <intent>.model     entities + relations + UI metadata
+       <process>.bpmn                     processes
+       <form>.form                        forms
+       <report>.report                    reports
+       <intent>.roles                     permissions
+       <intent>.glue                      triggers, resolvers, notifications, schedules, ...
+       <seed>.csvim + <seed>.csv          seed data
+5. Generate once more, one level down: open a generated model and run the template engine, or let the editor chain it.
+6. Publish. The registry receives intent + models + generated code together; the per-artefact synchronizers bring the runtime live as for any project.
+```
+
+## Project layout
+
+The folders layer cleanly, each owned by exactly one tool:
+
+| Folder | Owned by | Lifecycle |
+| --- | --- | --- |
+| `app.intent` | you (and the AI assistant) | the only hand-authored artefact |
+| project-root model files | the intent engine's Generate | re-emitted and scrubbed on every Generate |
+| `gen/` | the template engine | wiped wholesale on every regeneration |
+| `custom/` | you | the escape hatch, touched by nobody |
+
+Model-layer files at the project root are owned by the regeneration pass. **Do not hand-edit the generated `.edm` / `.bpmn` / `.form`** - changes are overwritten, and a file no longer backed by the intent is scrubbed on the next Generate. Adding `app.intent` to a classic project hands ownership of its root-level model files to the intent engine; migrate them into the intent first. A project without an `app.intent` stays "classic" and you hand-edit its models as before.
+
+## In this section
+
+- [The `.intent` file](/help/intent/intent-file) - the full YAML schema: entities, relations, processes, forms, reports, permissions, seeds, and the semantics that matter.
+- [The Intent Editor](/help/intent/editor) - the split editor, the live diagram, validation, and Generate.
+- [The AI assistant](/help/intent/ai-assistant) - Claude proposes a patch to the intent; you accept or refine.
+- [Generators and generation](/help/intent/generators) - what each generator produces, the regeneration contract, and `.settings`.
+- [Declarative glue](/help/intent/glue) - notifications, schedules, integrations, inbound webhooks, rollups and lifecycle triggers, generated as annotated client-Java.
+
+## See also
+
+- [Intent-Driven Application Development Manifesto](/manifesto/)
+- [The synchronizer model](/help/concepts/synchronizer-model)
+- [Generation from models](/help/develop/using-templates-for-generation)
+- [Entity Data modeler](/help/ide/modelers/entity-data)

--- a/docs/help/intent/intent-file.md
+++ b/docs/help/intent/intent-file.md
@@ -1,0 +1,271 @@
+---
+title: The .intent file
+description: The .intent YAML schema - entities, relations, processes, forms, reports, permissions, seeds - plus the semantics that drive generation.
+---
+
+# The `.intent` file
+
+One YAML document, at the project root, one per project. It is the whole application's intent in one place so the AI always diffs against full context and you always see the whole system at once. Content type `application/yaml+intent` (the `intent` extension) routes a double-click to the [Intent Editor](/help/intent/editor).
+
+YAML, not JSON: comments, multi-line strings, no quote noise, friendlier diffs. It is loaded with SnakeYAML's `SafeConstructor`, so `!!type` tags are blocked - the intent often arrives from LLM output or paste and must never be a code-execution surface.
+
+## A complete example
+
+This is the canonical, integration-test-verified showcase - one Orders intent exercising every block:
+
+```yaml
+name: orders
+description: Order management with approval workflow
+version: 1
+
+entities:
+  - name: Country
+    kind: setting
+    description: ISO 3166-1 country reference data
+    fields:
+      - { name: id,    type: integer, primaryKey: true, generated: true }
+      - { name: name,  type: string,  required: true, length: 100 }
+      - { name: code2, type: string,  length: 2 }
+
+  - name: Customer
+    fields:
+      - { name: id,          type: integer, primaryKey: true, generated: true }
+      - { name: name,        type: string,  required: true, length: 200 }
+      - { name: active,      type: boolean, defaultValue: "true" }
+      - { name: creditLimit, type: decimal }
+      - { name: orderCount,  type: integer }
+    relations:
+      - { name: country, kind: manyToOne, to: Country }
+      - { name: orders,  kind: oneToMany, to: Order }
+
+  - name: Order
+    fields:
+      - { name: id,        type: integer, primaryKey: true, generated: true }
+      - { name: orderDate, type: date,    required: true }
+      - { name: total,     type: decimal }
+    relations:
+      - { name: customer, kind: manyToOne, to: Customer }
+      - { name: items,    kind: oneToMany, to: OrderItem }
+
+  - name: OrderItem
+    fields:
+      - { name: id,       type: integer, primaryKey: true, generated: true }
+      - { name: quantity, type: integer, required: true }
+    relations:
+      - { name: order, kind: manyToOne, to: Order, composition: true }
+
+processes:
+  - name: OrderApproval
+    trigger: { onCreate: Order }
+    steps:
+      - { name: managerReview, kind: userTask, args: { assignee: manager, form: ApproveOrder } }
+      - { name: bigOrder,      kind: decision, args: { if: "customer.creditLimit > 10000", then: cfoReview, else: notifyCustomer } }
+      - { name: cfoReview,     kind: userTask, args: { assignee: cfo, form: ApproveOrder } }
+      - { name: notifyCustomer, kind: serviceTask }
+      - { name: done,          kind: end }
+
+forms:
+  - name: ApproveOrder
+    forEntity: Order
+    fields: [orderDate, total]
+    actions: [approve, reject]
+
+reports:
+  - name: OrdersByCustomer
+    source: Order
+    dimensions: [customer]
+    measures: ["count(*)", "sum(total)"]
+
+permissions:
+  - { role: Sales,   can: [Customer:read, Order:create] }
+  - { role: Manager, can: [Order:approve] }
+
+seeds:
+  - name: countries
+    entity: Country
+    rows:
+      - { id: 1, name: Afghanistan, code2: AF }
+      - { id: 2, name: Albania,     code2: AL }
+```
+
+Plus the [declarative-glue blocks](/help/intent/glue) (`notifications`, `schedules`, `integrations`, `inbound`, `rollups`).
+
+Every collection defaults to empty, so a partial intent (entities only) parses cleanly. Field names are camelCase.
+
+## entities
+
+```yaml
+entities:
+  - name: Customer          # PascalCase entity name
+    description: Buyer account
+    kind: setting           # optional - see "Setting entities"
+    fields: [ ... ]
+    relations: [ ... ]
+```
+
+### fields
+
+```yaml
+fields:
+  - { name: id,      type: integer, primaryKey: true, generated: true }
+  - { name: name,    type: string,  required: true, length: 200 }
+  - { name: total,   type: decimal }
+  - { name: active,  type: boolean, defaultValue: "true" }
+```
+
+| Key | Meaning |
+| --- | --- |
+| `name` | field name, camelCase (PascalCased in the generated model) |
+| `type` | logical type (see below) |
+| `primaryKey` | marks the PK; must be an integer type |
+| `generated` | auto-increment (integer PKs only) |
+| `required` | NOT NULL; the generated REST controller's required-value validation keys on this |
+| `length` | column length for string types |
+| `defaultValue` | column default |
+
+Logical types: `string`, `text`, `integer`, `int`, `long`, `decimal`, `double`, `boolean`, `date`, `timestamp`, `uuid`. Generators map them to JDBC + EDM types. `text` becomes a CLOB; `uuid` becomes `VARCHAR(36)`.
+
+**Primary keys must be an integer type** (`integer` / `int` / `long`). The Dirigible convention is an integer auto-increment id, and a non-integer auto-increment column is invalid SQL - the parser rejects a `uuid` or string PK. `uuid` is fine for non-PK fields.
+
+### relations
+
+```yaml
+relations:
+  - { name: customer, kind: manyToOne, to: Customer }
+  - { name: orders,   kind: oneToMany, to: Order }
+  - { name: order,    kind: manyToOne, to: Order, composition: true }
+```
+
+Relation kinds: `oneToMany`, `manyToOne`, `oneToOne`, `manyToMany`. The FK lives on the to-one side; the EDM generator ignores `oneToMany` / `manyToMany` (navigation-only) since the column is on the child.
+
+- **`required: true` on a to-one** makes the FK NOT NULL but keeps the entity a top-level entity with its own perspective (a plain dropdown).
+- **`composition: true` on a to-one** makes it a master-detail composition: the owning entity becomes DEPENDENT (managed as details under its parent's perspective), and the FK is NOT NULL (so `required` need not also be set). Only a `manyToOne` / `oneToOne` can be a composition; an entity's first `composition` to-one is its composition parent. Declare the inverse `oneToMany` on the master so the child is managed as a detail of it.
+
+Composition is **opt-in** - this matches the Dirigible convention where most required FKs are plain associations and composition is explicit.
+
+### Setting entities
+
+```yaml
+- name: Country
+  kind: setting
+```
+
+`kind: setting` marks an entity as nomenclature / configuration. It is generated with `type="SETTING"`, which the template engine routes under the dashboard's global **Settings** perspective instead of giving it its own perspective. Any relation **targeting** a setting entity resolves its dropdown to the `Settings` perspective. Settings are still real entities (own table, seeds, FK columns) - only their UI placement differs. Default `kind` (omitted) is a regular managed entity.
+
+## processes
+
+```yaml
+processes:
+  - name: OrderApproval
+    trigger: { onCreate: Order, when: "total > 0" }
+    steps:
+      - { name: managerReview, kind: userTask,    args: { assignee: manager, form: ApproveOrder } }
+      - { name: bigOrder,      kind: decision,    args: { if: "customer.creditLimit > 10000", then: cfoReview, else: notifyCustomer } }
+      - { name: cfoReview,     kind: userTask,    args: { assignee: cfo, form: ApproveOrder } }
+      - { name: notifyCustomer, kind: serviceTask }
+      - { name: done,          kind: end }
+```
+
+Generates one `<process>.bpmn` (Flowable-flavoured BPMN 2.0) plus the diagram interchange so the BPMN modeler renders it.
+
+Step kinds: `userTask`, `serviceTask`, `decision`, `script`, `end`.
+
+**Decision steps**: `if` + `then` are mandatory, `else` optional. `then` / `else` must name a declared step or the literal `end`; the parser validates this, so a typo fails at parse time rather than producing a Flowable reject. Without `else`, the gateway default falls through to the next step.
+
+A decision condition can walk **one hop** off the trigger entity (`customer.creditLimit > 10000`): the generator inserts a resolver service task before the gateway that loads the related entity and rewrites the condition to the resolved variable.
+
+### trigger
+
+`trigger: { onCreate | onUpdate | onDelete: <Entity>, when: "<expr>" }` starts the process on that entity's lifecycle event. Fully wired:
+
+- the parser validates at most one event kind, and that the target is a declared entity;
+- the EDM generator adds a `ProcessId` back-reference column to the entity (so the process starts at most once);
+- `template-application-events-java` emits a `gen/events/<Process>Trigger.java` `@Listener` that loads the entity, applies the `when` guard, calls `Process.start(...)`, and writes the instance id back.
+
+`when` supports a single `field ==|!= literal` guard. The **business key** defaults to the entity PK but is configurable:
+
+```yaml
+trigger: { onCreate: Order, businessKey: orderNo, businessKeyStrategy: timestamp }
+```
+
+`businessKey` names which field becomes the started instance's business key; `businessKeyStrategy: timestamp` mints a `yyyyMMddHHmmss` value into that field when it is blank (the field must be `string` / `text`). The strategy is the extension point for richer pluggable number generators later.
+
+## forms
+
+```yaml
+forms:
+  - name: ApproveOrder
+    forEntity: Order
+    fields: [orderDate, total]
+    actions: [approve, reject]
+```
+
+Generates one `<form>.form` per form. Controls are typed by looking each field up against the bound entity (string/uuid to text input, text to textarea, integer/decimal to number, boolean to checkbox, date to date picker, timestamp to datetime). Actions become buttons, coloured by name (approve to positive; reject/decline/delete/cancel to negative; save/submit to emphasized). A stub controller declares `on<Action>Clicked` handlers as TODOs - real wiring is a downstream template or a `custom/` override.
+
+## reports
+
+```yaml
+reports:
+  - name: OrdersByCustomer
+    source: Order
+    dimensions: [customer]                 # bare to-one shows the target's label, not the FK id
+    measures: ["count(*)", "sum(total)"]
+  - name: BigOrderItems
+    source: OrderItem
+    dimensions: [order.orderDate, quantity] # relation.field path -> INNER JOIN
+    filter: "quantity > 1"                   # -> WHERE
+```
+
+Generates one `<report>.report` per report, in the Dirigible `.report` shape with a fully materialised SQL `query`. Rooted at `source`:
+
+- a plain field resolves to a source column;
+- a `relation.field` path (`order.orderDate`) adds an `INNER JOIN` to the related entity plus a column on it;
+- a bare to-one relation (`customer`) joins and shows the target's label (`name`-like) field, not the raw FK id - use `customer.id` for the id;
+- a measure `count(*)` / `sum(...)` / `avg` / `min` / `max` becomes an aggregate, and the dimensions become the `GROUP BY`.
+
+`filter` becomes the `WHERE` with field names rewritten to qualified physical columns. All physical identifiers in the query are double-quoted for Postgres compatibility. Keep entity names non-reserved (avoid `Order` as a bare alias source on reserved-word databases).
+
+## permissions
+
+```yaml
+permissions:
+  - { role: Sales,   can: [Customer:read, Order:create] }
+  - { role: Manager, can: [Order:approve] }
+```
+
+Generates `<intent>.roles` (deduped by role name). It deliberately does **not** emit `.access` URL constraints - URL-shaped rules belong to whichever downstream template materialises the UI, because only that template knows the paths it publishes. The `can: [Resource:action]` tokens are an authoring hint to those downstream generators about which actions each role may invoke.
+
+## seeds
+
+```yaml
+seeds:
+  - name: countries
+    entity: Country
+    rows:
+      - { id: 1, name: Afghanistan, code2: AF }
+      - { id: 2, name: Albania,     code2: AL }
+```
+
+Generates `<seed>.csvim` + `<seed>.csv` per seed. The CSV header carries `<ENTITY>_<FIELD>` upper-snake column names; row order matches the entity's declared field order. The target table only exists after the downstream "Generate from EDM" output is published, so the CSVIM import retries via its own synchronizer until then.
+
+## Naming and tables
+
+- The top-level `name:` is the intent's identity. Single-file outputs are `<name>.edm` / `.model` / `.roles` / `.glue`; the table prefix is its upper-snake.
+- Physical table names are **intent-prefixed**: `<INTENT>_<ENTITY>` upper-snake (`ORDERS_ORDER`), applied consistently across `.edm`, `.report` and `.csvim`. This dodges SQL reserved words and cross-project collisions in a shared schema. When the downstream "Generate from EDM" wizard asks for a table prefix, leave it empty - the prefix is already in the model.
+- Property names are PascalCase in the generated model (`loanedOn` to `LoanedOn`); physical columns stay UPPER_SNAKE. You author in lower camelCase.
+
+## Authoring rules
+
+- **Comments are encouraged.** No tool ever rewrites the intent, so developer comments stay put; the AI patch path is prompted to preserve them.
+- **No anchors / aliases** (`&foo` / `*foo`) at v1 - they make diffs harder for the AI. Prefer a `defaults:` block if duplication hurts.
+- **No multi-document YAML** (`---`). One file, one document.
+- **No tags** (already enforced by `SafeConstructor`).
+- **Quote unquoted braces in scalars.** `to: {member.email}` is parsed by YAML as an object, not a string - write `to: member.email` (braces are only for `{...}` interpolation inside `subject` / `body`).
+- An event-binding key is `event:`, never `on:` - YAML 1.1 resolves a bare `on` to boolean `true`. An action key is `do:`.
+
+## See also
+
+- [The Intent Editor](/help/intent/editor)
+- [Generators and generation](/help/intent/generators)
+- [Declarative glue](/help/intent/glue)
+- [Entity Data modeler](/help/ide/modelers/entity-data) - the model the entities generate into

--- a/docs/help/reference/artefact-extensions.md
+++ b/docs/help/reference/artefact-extensions.md
@@ -53,6 +53,8 @@ These are model artefacts; generation produces runtime artefacts from them.
 
 | Extension | Modeler | Generates |
 | --------- | ------- | --------- |
+| `*.intent` | [Intent Editor](/help/intent/editor) | All the model artefacts below - `.edm` / `.bpmn` / `.form` / `.report` / `.roles` / `.glue` / `.csvim` - one altitude up |
+| `*.glue` | (generated from `*.intent`) | Annotated client-Java glue (`@Listener` / `@Scheduled` / `@Controller`) under `gen/events` |
 | `*.edm`, `*.model` | [Entity Data modeler](/help/ide/modelers/entity-data) | Full CRUD app via `template-application-*` |
 | `*.dsm` | [Database Schema modeler](/help/ide/modelers/database-schema) | `.schema` + `.table` + `.view` |
 | `*.form` | [Form Designer](/help/ide/modelers/form-designer) | HTML form layout |
@@ -60,5 +62,6 @@ These are model artefacts; generation produces runtime artefacts from them.
 
 ## See also
 
+- [Intent](/help/intent/) - the `.intent` authoring layer above these models
 - [Synchronizer model](/help/concepts/synchronizer-model)
 - [Artefacts overview](/help/artefacts/)

--- a/docs/manifesto/index.md
+++ b/docs/manifesto/index.md
@@ -7,6 +7,8 @@ description: Business intent, captured as a canonical model, regenerated determi
 
 *Business intent, captured as a canonical model, regenerated deterministically into running software.*
 
+> Looking for the feature, not the philosophy? See the [Intent documentation](/help/intent/) - the `.intent` file, the editor, the AI assistant, and the generators.
+
 ---
 
 ## Preamble
@@ -262,6 +264,8 @@ In practice, for the developer, the whole discipline collapses to this:
 6. Publish. The platform brings the application live exactly as it would for any hand-modelled project.
 
 No modeller expertise required to start. No clicks-and-tweaks tax to pay. No divergence between model and code. The abstraction MDD always promised, reached through a door humans will actually walk through.
+
+For the concrete mechanics of each step - the `.intent` schema, the editor, the AI assistant and the generators - see the [Intent documentation](/help/intent/).
 
 ---
 


### PR DESCRIPTION
Adds a dedicated `/help/intent/` documentation section for the intent-driven authoring layer (engine-intent), plus cross-links.

## Pages
- Overview, the `.intent` file schema, the Intent Editor, the AI assistant, generators and generation, declarative glue.

## Wiring
- New *Intent* group in the help sidebar
- Intent bullet on the help landing page
- `*.intent` / `*.glue` rows in the artefact-extensions reference
- Links from the Intent-Driven Application Development manifesto

Build verified clean (`npm run docs:build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)