### PR TITLE
Document the Harmonia runtime UI stack + latest Intent features

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -325,6 +325,7 @@ function helpSidebar() {
         { text: 'Working with files and CMS', link: '/help/develop/working-with-files-and-cms' },
         { text: 'Working with Git', link: '/help/develop/working-with-git' },
         { text: 'Generation from models', link: '/help/develop/using-templates-for-generation' },
+        { text: 'Harmonia runtime UI', link: '/help/develop/harmonia-runtime-ui' },
         { text: 'Debugging JavaScript', link: '/help/develop/debugging-javascript' },
         { text: 'Debugging Java', link: '/help/develop/debugging-java' },
         { text: 'Testing', link: '/help/develop/testing' },

--- a/docs/help/develop/harmonia-runtime-ui.md
+++ b/docs/help/develop/harmonia-runtime-ui.md
@@ -1,0 +1,89 @@
+---
+title: Harmonia runtime UI
+description: The Alpine.js + Harmonia generation stack - a self-contained single-page app served as a web resource, the runtime-UI alternative to the Angular stack.
+---
+
+# Harmonia runtime UI
+
+Dirigible generates the runtime UI for a model in one of two stacks. The **Angular + BlimpKit** stack generates one iframe perspective per entity, hosted by the platform dashboard over the `postMessage` hub protocol. The **Alpine.js + Harmonia** stack generates a single client-routed single-page application served as a plain web resource. Both consume the same model and the **same generated Java REST/DAO backend** (`template-application-rest-java`); only the UI layer differs.
+
+The IDE itself - Workbench, Monaco editors, the entity / form / intent modelers - stays on Angular + BlimpKit. Harmonia is a **runtime** stack: generated and custom apps, their shell, views, forms and BPM task forms. The two stacks coexist by URL, not by a shared seam: the IDE shell at its own URL, each Harmonia app as a standalone SPA at `/services/web/<project>/`.
+
+## Picking the stack
+
+Choose the stack when you generate the application UI:
+
+| Template | Stack | Produces |
+| --- | --- | --- |
+| `template-application-ui-angular-java` | Angular + BlimpKit | iframe-per-entity perspectives, hosted by the dashboard |
+| `template-application-ui-harmonia-java` | Alpine.js + Harmonia | a single client-routed SPA per app |
+| `template-form-builder-angularjs` | Angular + BlimpKit | a runtime `.form` as an Angular page |
+| `template-form-builder-harmonia` | Alpine.js + Harmonia | a runtime `.form` as a Harmonia page |
+
+The model-layer generators (EDM / intent / DAO / REST) and the Java backend are identical across both - the choice is the UI template only. The intent recipe (`<intent>.settings`) can point its `form` and UI templates at the Harmonia variants.
+
+## What gets generated
+
+A complete, runnable SPA under `gen/<genFolder>/`:
+
+```
+gen/<genFolder>/
+  index.html                          # aggregate shell: x-h-split layout, sidebar,
+                                       #   breadcrumb, <template x-route> per entity
+  css/app.css
+  js/app.js                           # window.App namespace
+  js/config.js                        # GENERATED - projectName, basePath, restBase
+  js/services/api.js                  # fetch client + ApiError
+  js/services/apiError.js             # localizable, user-safe error catalog
+  js/services/formValidation.js       # schema validator
+  js/components/layout/appShell.js     # the reusable dashboard (Alpine.data 'app')
+  js/components/pages/basePage.js
+  js/components/pages/baseFormPage.js   # 422 errorCauses -> per-field mapping
+  js/components/pages/<persp>/<Entity>ListPage.js   # one per LIST entity
+  views/<persp>/<entity>-list.html      # one per LIST entity (Harmonia fragment)
+  views/_notfound.html
+```
+
+Shared assets are copied verbatim; the only project-specific shell file is `js/config.js`, so the verbatim JS is never Velocity-processed (which would collide with its `$` sigils).
+
+## Architecture
+
+- **Single page, no iframes, no hubs.** [Pinecone Router](https://github.com/rehhouari/pinecone-router) (hash mode, `basePath: '/services/web/<project>'`) declares routes as `<template x-route="/customers" ...>` and renders the matched view fragment into one `<div id="app">`. Each view's root element is an `Alpine.data(...)` page component whose `init()` runs on entry and `destroy()` on exit - fresh per-visit state.
+- **`window.App = { services, routes, utils }`** is the global namespace (CDN / no-build style). Stores via `Alpine.store(...)`, pages via `Alpine.data(...)`, services framework-agnostic.
+- **Layout** uses Harmonia's `x-h-split` / `x-h-split-panel` for both the sidebar/main division and master-detail views. The shell (`appShell.js`) provides sidebar nav, a top toolbar with a breadcrumb trail derived from the route, a notifications popover, an avatar menu with a light/dark/auto theme switch, and a responsive collapse that re-parents the sidebar into an `x-h-sheet` drawer below 1024 px.
+
+## View types
+
+| View | Status |
+| --- | --- |
+| list | read-only list page + fragment |
+| manage | CRUD list + shared create/edit form (relationship dropdowns, client validation, 422 field mapping, delete-confirm) |
+| setting | reuses the manage CRUD, grouped under a **Settings** sidebar section |
+| master-detail | `x-h-split` master list + the selected record's detail panels via a runtime registry |
+| reports | in-SPA data table (CSV export) + chart.js charts (bar / line / pie / doughnut / polarArea / radar); standalone `.report` files render as a self-contained Harmonia page |
+| forms + BPM task forms | rendered by `template-form-builder-harmonia` via the neutral `formController(ctx)` contract |
+| Process Inbox (built-in `/inbox`) | Outlook-style master-detail: task list left, the selected task's form inline right, claim-before-open, auto-refresh |
+| Documents (built-in `/documents`) | full Document Storage master-detail: file list + preview pane (CSV to table, others via `/preview`), upload, zip, rename, delete, search |
+| process tasks | a `processTasks` store fetches `/services/inbox/tasks`, buckets by process instance, surfaces inline task popovers in list / manage / master rows and completes through an app-wide task-form dialog |
+
+## Runtime contracts
+
+These are the invariants the generated SPA relies on:
+
+- **REST base** - `restBase` = `/services/java/<project>/gen/<javaGenFolderName>/api`; each entity page uses a relative `apiPath` = `/<javaPerspectiveName>/<Entity>Controller` and the fetch client prepends `restBase` exactly once. The path uses the **Java-sanitised** folder / perspective names (`sales-order` -> `sales_order`), since the backend package is sanitised. Absolute URLs (relationship dropdowns) pass `{ baseUrl: '' }`.
+- **Neutral form contract** - a `.form`'s `code` is the body of `formController(ctx)` with `ctx.{ model, params, http, task: { id, processInstanceId, complete() }, notify, close }`. BPM task forms complete via `ctx.task.complete()`.
+- **Master-detail registry** - each detail registers its metadata via `App.registerDetail(<master>, ...)`, so masters render detail panels without enumerating details at generation time.
+- **Dates** - forms convert HTML date / datetime / time widget values to the backend `java.time` format on submit and back for edit display.
+
+## Embedding
+
+The whole stack is built into the fat jar - no CDN, for CSP and offline. Alpine, Harmonia, Lucide and chart.js are **webjars** served version-less at `/webjars/...`; Pinecone Router (no published webjar) is vendored under `application-core/.../vendor/`. The generated `index.html` references only these local URLs.
+
+Harmonia's CSS is a fixed, curated Tailwind subset (no build step): unknown utilities silently render as nothing, so stay inside the allow-list or use inline `style=` / CSS variables. Theming is CSS-variable based via `Harmonia.setColorScheme('light' | 'dark' | 'auto')`.
+
+## See also
+
+- [Generation from models](/help/develop/using-templates-for-generation)
+- [Intent](/help/intent/) - an intent project can target the Harmonia form / UI templates via `.settings`
+- [The polyglot runtime](/help/concepts/polyglot-runtime)
+- [Entity Data modeler](/help/ide/modelers/entity-data)

--- a/docs/help/develop/using-templates-for-generation.md
+++ b/docs/help/develop/using-templates-for-generation.md
@@ -11,7 +11,7 @@ Dirigible ships a library of templates that generate either a full application o
 
 | Family | Examples | What it produces |
 | ------ | -------- | ---------------- |
-| **Application** | `template-application-angular`, `…-angular-java`, `…-angular-v2`, `template-application-dao`, `…-rest`, `…-data`, `…-feed`, `…-odata`, `…-schema`, `…-ui-angular` | Full CRUD app: tables, REST endpoints, OData, UI. Driven by an EDM model. |
+| **Application** | `template-application-angular`, `…-angular-java`, `…-ui-harmonia-java`, `…-angular-v2`, `template-application-dao`, `…-rest`, `…-data`, `…-feed`, `…-odata`, `…-schema`, `…-ui-angular` | Full CRUD app: tables, REST endpoints, OData, UI. Driven by an EDM model. |
 | **Single artefact** | `template-bpm`, `template-camel`, `template-camel-cron-route`, `template-camel-http-route`, `template-database-access`, `template-database-table`, `template-database-view`, `template-editor`, `template-extension-perspective`, `template-extension-view`, `template-form`, `template-form-builder-angularjs`, `template-html`, `template-http-client`, `template-job`, `template-listener`, `template-mapping-javascript`, `template-perspective`, `template-react`, `template-typescript`, `template-view`, `template-websocket` | One file or a tight bundle of files for the named artefact. |
 
 Sample-project templates: `template-bookstore`, `template-hello-world`.
@@ -24,7 +24,9 @@ The Entity Data Modeler (`*.edm`) is the canonical input to the application temp
 2. Drag entities, add fields, draw associations.
 3. Right-click the model, choose **Generate Application**, pick a template, set the target project name.
 
-The platform emits tables, OData services, REST endpoints, an Angular UI, and per-entity perspectives.
+The platform emits tables, OData services, REST endpoints, a UI, and per-entity perspectives.
+
+The runtime UI is generated in one of two stacks - **Angular + BlimpKit** (iframe-per-entity perspectives hosted by the dashboard) or **Alpine.js + Harmonia** (a single client-routed SPA). Both consume the same model and the same Java backend. See [Harmonia runtime UI](/help/develop/harmonia-runtime-ui).
 
 ## Generating from a Database Schema model
 

--- a/docs/help/intent/intent-file.md
+++ b/docs/help/intent/intent-file.md
@@ -122,10 +122,36 @@ fields:
 | `required` | NOT NULL; the generated REST controller's required-value validation keys on this |
 | `length` | column length for string types |
 | `defaultValue` | column default |
+| `unique` | a UNIQUE constraint (e.g. a code or a business key) |
+| `precision` / `scale` | override the DECIMAL default (16, 2): `{ name: rate, type: decimal, precision: 18, scale: 6 }` |
+| `calculatedOnCreate` / `calculatedOnUpdate` | an expression the generated repository assigns to the property on insert / update |
+| `calculatedActionOnCreate` / `calculatedActionOnUpdate` | a server-side action call-out - see "Calculated fields" |
 
 Logical types: `string`, `text`, `integer`, `int`, `long`, `decimal`, `double`, `boolean`, `date`, `timestamp`, `uuid`. Generators map them to JDBC + EDM types. `text` becomes a CLOB; `uuid` becomes `VARCHAR(36)`.
 
 **Primary keys must be an integer type** (`integer` / `int` / `long`). The Dirigible convention is an integer auto-increment id, and a non-integer auto-increment column is invalid SQL - the parser rejects a `uuid` or string PK. `uuid` is fine for non-PK fields.
+
+`audit: true` on an **entity** adds the four standard audit columns (`CreatedAt`, `CreatedBy`, `UpdatedAt`, `UpdatedBy`), populated by the platform's audit annotations.
+
+### Calculated fields
+
+A field value can be derived on insert / update instead of being entered:
+
+- **`calculatedOnCreate` / `calculatedOnUpdate`** - an expression the generated repository assigns to the property. Prefer a **neutral arithmetic expression** for numeric totals (`"Quantity * Price"`, `"round(Net * 0.2, 2)"`): the SDK `Calc` evaluator runs it on the server and the UI previews it live with the same evaluator. A non-numeric field's expression is emitted verbatim, so it must be valid Java for the Java DAO (e.g. `"java.util.UUID.randomUUID().toString()"`).
+- **`calculatedActionOnCreate` / `calculatedActionOnUpdate`** - a server-side call-out for logic too custom to model (conditional / sequential number generation, lookups). The value names a Java class - a `@Component` implementing `org.eclipse.dirigible.sdk.db.CalculatedField<E, T>` (`T calculate(E entity)`) - that the repository invokes via `Beans.get(<class>.class).calculate(entity)`. It runs **server-side only** (no live preview) and **takes precedence** over the expression on the same slot. The implementation is hand-written by you under `custom/` (never `gen/`); the intent emits no Java.
+
+To reference an action class by simple name, the entity declares `imports:` - a multi-line string of Java `import ...;` lines injected verbatim into the generated repository:
+
+```yaml
+entities:
+  - name: SalesInvoice
+    imports: |
+      import custom.sales_invoices.SalesInvoiceNumberAction;
+    fields:
+      - { name: number, type: string, length: 100, calculatedActionOnCreate: SalesInvoiceNumberAction }
+```
+
+You then add `custom/sales_invoices/SalesInvoiceNumberAction.java`. Alternatively give the fully-qualified class name and omit the import.
 
 ### relations
 
@@ -151,6 +177,43 @@ Composition is **opt-in** - this matches the Dirigible convention where most req
 ```
 
 `kind: setting` marks an entity as nomenclature / configuration. It is generated with `type="SETTING"`, which the template engine routes under the dashboard's global **Settings** perspective instead of giving it its own perspective. Any relation **targeting** a setting entity resolves its dropdown to the `Settings` perspective. Settings are still real entities (own table, seeds, FK columns) - only their UI placement differs. Default `kind` (omitted) is a regular managed entity.
+
+### Cross-model references (`uses`)
+
+A relation can target an entity owned by a **different** project's intent model - master / reference data (`Customer`, `Country`, `Currency`, `UoM`) you do not want to redefine. The owner model owns the single table; this model stores an integer FK and renders a dropdown sourced from the owner's REST service. It does **not** generate the owner's table or API.
+
+Declare the dependencies in a top-level `uses:` block, then point a `manyToOne` / `oneToOne` relation at the alias with `model:`:
+
+```yaml
+name: customers
+uses:
+  - { model: countries }                        # project defaults to the model alias
+  - { model: currencies, project: currencies }   # set project when it differs from the alias
+entities:
+  - name: Customer
+    fields:
+      - { name: id,   type: integer, primaryKey: true, generated: true }
+      - { name: name, type: string,  required: true }
+    relations:
+      - { name: Country,  kind: manyToOne, to: Country,  model: countries }
+      - { name: Currency, kind: manyToOne, to: Currency, model: currencies }
+```
+
+A cross-model relation must be `manyToOne` / `oneToOne`, its `model:` must be listed in `uses:`, and it **cannot** be `composition: true` (a detail cannot be owned across models). Generate the owner (leaf) models before their consumers so the dropdown resolves; each project is its own `.intent` and all must be published to the same runtime. Under the hood this reuses the platform's PROJECTION mechanism.
+
+### Many-to-many
+
+There is no `manyToMany` materialisation. Model n:m as an **explicit intermediate entity** holding a `composition` to one side, a `manyToOne` to the other (which may be cross-model via `model:`), plus any bridge fields:
+
+```yaml
+  - name: SalesInvoiceCustomerPayment
+    fields:
+      - { name: id,     type: integer, primaryKey: true, generated: true }
+      - { name: amount, type: decimal, precision: 18, scale: 2, required: true }   # partial allocation
+    relations:
+      - { name: SalesInvoice,    kind: manyToOne, to: SalesInvoice,    composition: true, required: true }
+      - { name: CustomerPayment, kind: manyToOne, to: CustomerPayment, model: customer-payments, required: true }
+```
 
 ## processes
 


### PR DESCRIPTION
## What

Documents the noteworthy platform changes that landed in `dirigible-io/dirigible` since the Intent docs were last updated (June 20).

### Harmonia runtime UI (new page)
`/help/develop/harmonia-runtime-ui` documents the **Alpine.js + Harmonia** generation stack - a single client-routed SPA served as a web resource, the runtime-UI alternative to **Angular + BlimpKit**. Covers:
- the stack picker (`template-application-ui-harmonia-java` / `template-form-builder-harmonia` vs the Angular variants), same model and same Java backend
- the generated SPA layout, single-page/Pinecone-router architecture (no iframes, no hubs)
- view types (list / manage / setting / master-detail / reports / forms + BPM task forms / built-in Process Inbox + Documents / inline process tasks)
- runtime contracts (REST base, neutral `formController(ctx)`, master-detail registry, dates) and the webjar embedding model

Also wired into the Develop sidebar and cross-linked from the generation page (which now frames the two UI stacks).

### Intent `.intent` file (updates)
Brought the schema doc up to date with the latest intent features:
- **field attributes** - `unique`, `precision`/`scale`, calculated fields (`calculatedOnCreate/Update`) and server-side calculated **actions** (`calculatedActionOnCreate/Update` + the `CalculatedField` SDK interface), entity-level `audit: true`, and `imports:`
- **cross-model references** via the top-level `uses:` block + `model:` on a relation (PROJECTION-backed)
- **many-to-many** via an explicit intermediate entity

## Verification
- `npm run docs:build` passes clean.
- All cross-links resolve to existing pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)