### PR TITLE
Document multi-model intent apps: shared shell, reuse, packaging

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -325,6 +325,7 @@ function helpSidebar() {
         { text: 'Working with files and CMS', link: '/help/develop/working-with-files-and-cms' },
         { text: 'Working with Git', link: '/help/develop/working-with-git' },
         { text: 'Generation from models', link: '/help/develop/using-templates-for-generation' },
+        { text: 'Harmonia runtime UI', link: '/help/develop/harmonia-runtime-ui' },
         { text: 'Debugging JavaScript', link: '/help/develop/debugging-javascript' },
         { text: 'Debugging Java', link: '/help/develop/debugging-java' },
         { text: 'Testing', link: '/help/develop/testing' },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -201,6 +201,7 @@ function helpSidebar() {
       items: [
         { text: 'Overview', link: '/help/intent/' },
         { text: 'The .intent file', link: '/help/intent/intent-file' },
+        { text: 'Multi-model applications', link: '/help/intent/multi-model' },
         { text: 'The Intent Editor', link: '/help/intent/editor' },
         { text: 'The AI assistant', link: '/help/intent/ai-assistant' },
         { text: 'Generators and generation', link: '/help/intent/generators' },

--- a/docs/help/develop/harmonia-runtime-ui.md
+++ b/docs/help/develop/harmonia-runtime-ui.md
@@ -1,0 +1,89 @@
+---
+title: Harmonia runtime UI
+description: The Alpine.js + Harmonia generation stack - a self-contained single-page app served as a web resource, the runtime-UI alternative to the Angular stack.
+---
+
+# Harmonia runtime UI
+
+Dirigible generates the runtime UI for a model in one of two stacks. The **Angular + BlimpKit** stack generates one iframe perspective per entity, hosted by the platform dashboard over the `postMessage` hub protocol. The **Alpine.js + Harmonia** stack generates a single client-routed single-page application served as a plain web resource. Both consume the same model and the **same generated Java REST/DAO backend** (`template-application-rest-java`); only the UI layer differs.
+
+The IDE itself - Workbench, Monaco editors, the entity / form / intent modelers - stays on Angular + BlimpKit. Harmonia is a **runtime** stack: generated and custom apps, their shell, views, forms and BPM task forms. The two stacks coexist by URL, not by a shared seam: the IDE shell at its own URL, each Harmonia app as a standalone SPA at `/services/web/<project>/`.
+
+## Picking the stack
+
+Choose the stack when you generate the application UI:
+
+| Template | Stack | Produces |
+| --- | --- | --- |
+| `template-application-ui-angular-java` | Angular + BlimpKit | iframe-per-entity perspectives, hosted by the dashboard |
+| `template-application-ui-harmonia-java` | Alpine.js + Harmonia | a single client-routed SPA per app |
+| `template-form-builder-angularjs` | Angular + BlimpKit | a runtime `.form` as an Angular page |
+| `template-form-builder-harmonia` | Alpine.js + Harmonia | a runtime `.form` as a Harmonia page |
+
+The model-layer generators (EDM / intent / DAO / REST) and the Java backend are identical across both - the choice is the UI template only. The intent recipe (`<intent>.settings`) can point its `form` and UI templates at the Harmonia variants.
+
+## What gets generated
+
+A complete, runnable SPA under `gen/<genFolder>/`:
+
+```
+gen/<genFolder>/
+  index.html                          # aggregate shell: x-h-split layout, sidebar,
+                                       #   breadcrumb, <template x-route> per entity
+  css/app.css
+  js/app.js                           # window.App namespace
+  js/config.js                        # GENERATED - projectName, basePath, restBase
+  js/services/api.js                  # fetch client + ApiError
+  js/services/apiError.js             # localizable, user-safe error catalog
+  js/services/formValidation.js       # schema validator
+  js/components/layout/appShell.js     # the reusable dashboard (Alpine.data 'app')
+  js/components/pages/basePage.js
+  js/components/pages/baseFormPage.js   # 422 errorCauses -> per-field mapping
+  js/components/pages/<persp>/<Entity>ListPage.js   # one per LIST entity
+  views/<persp>/<entity>-list.html      # one per LIST entity (Harmonia fragment)
+  views/_notfound.html
+```
+
+Shared assets are copied verbatim; the only project-specific shell file is `js/config.js`, so the verbatim JS is never Velocity-processed (which would collide with its `$` sigils).
+
+## Architecture
+
+- **Single page, no iframes, no hubs.** [Pinecone Router](https://github.com/rehhouari/pinecone-router) (hash mode, `basePath: '/services/web/<project>'`) declares routes as `<template x-route="/customers" ...>` and renders the matched view fragment into one `<div id="app">`. Each view's root element is an `Alpine.data(...)` page component whose `init()` runs on entry and `destroy()` on exit - fresh per-visit state.
+- **`window.App = { services, routes, utils }`** is the global namespace (CDN / no-build style). Stores via `Alpine.store(...)`, pages via `Alpine.data(...)`, services framework-agnostic.
+- **Layout** uses Harmonia's `x-h-split` / `x-h-split-panel` for both the sidebar/main division and master-detail views. The shell (`appShell.js`) provides sidebar nav, a top toolbar with a breadcrumb trail derived from the route, a notifications popover, an avatar menu with a light/dark/auto theme switch, and a responsive collapse that re-parents the sidebar into an `x-h-sheet` drawer below 1024 px.
+
+## View types
+
+| View | Status |
+| --- | --- |
+| list | read-only list page + fragment |
+| manage | CRUD list + shared create/edit form (relationship dropdowns, client validation, 422 field mapping, delete-confirm) |
+| setting | reuses the manage CRUD, grouped under a **Settings** sidebar section |
+| master-detail | `x-h-split` master list + the selected record's detail panels via a runtime registry |
+| reports | in-SPA data table (CSV export) + chart.js charts (bar / line / pie / doughnut / polarArea / radar); standalone `.report` files render as a self-contained Harmonia page |
+| forms + BPM task forms | rendered by `template-form-builder-harmonia` via the neutral `formController(ctx)` contract |
+| Process Inbox (built-in `/inbox`) | Outlook-style master-detail: task list left, the selected task's form inline right, claim-before-open, auto-refresh |
+| Documents (built-in `/documents`) | full Document Storage master-detail: file list + preview pane (CSV to table, others via `/preview`), upload, zip, rename, delete, search |
+| process tasks | a `processTasks` store fetches `/services/inbox/tasks`, buckets by process instance, surfaces inline task popovers in list / manage / master rows and completes through an app-wide task-form dialog |
+
+## Runtime contracts
+
+These are the invariants the generated SPA relies on:
+
+- **REST base** - `restBase` = `/services/java/<project>/gen/<javaGenFolderName>/api`; each entity page uses a relative `apiPath` = `/<javaPerspectiveName>/<Entity>Controller` and the fetch client prepends `restBase` exactly once. The path uses the **Java-sanitised** folder / perspective names (`sales-order` -> `sales_order`), since the backend package is sanitised. Absolute URLs (relationship dropdowns) pass `{ baseUrl: '' }`.
+- **Neutral form contract** - a `.form`'s `code` is the body of `formController(ctx)` with `ctx.{ model, params, http, task: { id, processInstanceId, complete() }, notify, close }`. BPM task forms complete via `ctx.task.complete()`.
+- **Master-detail registry** - each detail registers its metadata via `App.registerDetail(<master>, ...)`, so masters render detail panels without enumerating details at generation time.
+- **Dates** - forms convert HTML date / datetime / time widget values to the backend `java.time` format on submit and back for edit display.
+
+## Embedding
+
+The whole stack is built into the fat jar - no CDN, for CSP and offline. Alpine, Harmonia, Lucide and chart.js are **webjars** served version-less at `/webjars/...`; Pinecone Router (no published webjar) is vendored under `application-core/.../vendor/`. The generated `index.html` references only these local URLs.
+
+Harmonia's CSS is a fixed, curated Tailwind subset (no build step): unknown utilities silently render as nothing, so stay inside the allow-list or use inline `style=` / CSS variables. Theming is CSS-variable based via `Harmonia.setColorScheme('light' | 'dark' | 'auto')`.
+
+## See also
+
+- [Generation from models](/help/develop/using-templates-for-generation)
+- [Intent](/help/intent/) - an intent project can target the Harmonia form / UI templates via `.settings`
+- [The polyglot runtime](/help/concepts/polyglot-runtime)
+- [Entity Data modeler](/help/ide/modelers/entity-data)

--- a/docs/help/develop/using-templates-for-generation.md
+++ b/docs/help/develop/using-templates-for-generation.md
@@ -11,7 +11,7 @@ Dirigible ships a library of templates that generate either a full application o
 
 | Family | Examples | What it produces |
 | ------ | -------- | ---------------- |
-| **Application** | `template-application-angular`, `…-angular-java`, `…-angular-v2`, `template-application-dao`, `…-rest`, `…-data`, `…-feed`, `…-odata`, `…-schema`, `…-ui-angular` | Full CRUD app: tables, REST endpoints, OData, UI. Driven by an EDM model. |
+| **Application** | `template-application-angular`, `…-angular-java`, `…-ui-harmonia-java`, `…-angular-v2`, `template-application-dao`, `…-rest`, `…-data`, `…-feed`, `…-odata`, `…-schema`, `…-ui-angular` | Full CRUD app: tables, REST endpoints, OData, UI. Driven by an EDM model. |
 | **Single artefact** | `template-bpm`, `template-camel`, `template-camel-cron-route`, `template-camel-http-route`, `template-database-access`, `template-database-table`, `template-database-view`, `template-editor`, `template-extension-perspective`, `template-extension-view`, `template-form`, `template-form-builder-angularjs`, `template-html`, `template-http-client`, `template-job`, `template-listener`, `template-mapping-javascript`, `template-perspective`, `template-react`, `template-typescript`, `template-view`, `template-websocket` | One file or a tight bundle of files for the named artefact. |
 
 Sample-project templates: `template-bookstore`, `template-hello-world`.
@@ -24,7 +24,9 @@ The Entity Data Modeler (`*.edm`) is the canonical input to the application temp
 2. Drag entities, add fields, draw associations.
 3. Right-click the model, choose **Generate Application**, pick a template, set the target project name.
 
-The platform emits tables, OData services, REST endpoints, an Angular UI, and per-entity perspectives.
+The platform emits tables, OData services, REST endpoints, a UI, and per-entity perspectives.
+
+The runtime UI is generated in one of two stacks - **Angular + BlimpKit** (iframe-per-entity perspectives hosted by the dashboard) or **Alpine.js + Harmonia** (a single client-routed SPA). Both consume the same model and the same Java backend. See [Harmonia runtime UI](/help/develop/harmonia-runtime-ui).
 
 ## Generating from a Database Schema model
 

--- a/docs/help/intent/index.md
+++ b/docs/help/intent/index.md
@@ -63,6 +63,7 @@ Model-layer files at the project root are owned by the regeneration pass. **Do n
 ## In this section
 
 - [The `.intent` file](/help/intent/intent-file) - the full YAML schema: entities, relations, processes, forms, reports, permissions, seeds, and the semantics that matter.
+- [Multi-model applications](/help/intent/multi-model) - split a domain into several intent modules that reference each other across models, reuse single master-data entities, and contribute to one shared shell.
 - [The Intent Editor](/help/intent/editor) - the split editor, the live diagram, validation, and Generate.
 - [The AI assistant](/help/intent/ai-assistant) - Claude proposes a patch to the intent; you accept or refine.
 - [Generators and generation](/help/intent/generators) - what each generator produces, the regeneration contract, and `.settings`.

--- a/docs/help/intent/intent-file.md
+++ b/docs/help/intent/intent-file.md
@@ -122,10 +122,36 @@ fields:
 | `required` | NOT NULL; the generated REST controller's required-value validation keys on this |
 | `length` | column length for string types |
 | `defaultValue` | column default |
+| `unique` | a UNIQUE constraint (e.g. a code or a business key) |
+| `precision` / `scale` | override the DECIMAL default (16, 2): `{ name: rate, type: decimal, precision: 18, scale: 6 }` |
+| `calculatedOnCreate` / `calculatedOnUpdate` | an expression the generated repository assigns to the property on insert / update |
+| `calculatedActionOnCreate` / `calculatedActionOnUpdate` | a server-side action call-out - see "Calculated fields" |
 
 Logical types: `string`, `text`, `integer`, `int`, `long`, `decimal`, `double`, `boolean`, `date`, `timestamp`, `uuid`. Generators map them to JDBC + EDM types. `text` becomes a CLOB; `uuid` becomes `VARCHAR(36)`.
 
 **Primary keys must be an integer type** (`integer` / `int` / `long`). The Dirigible convention is an integer auto-increment id, and a non-integer auto-increment column is invalid SQL - the parser rejects a `uuid` or string PK. `uuid` is fine for non-PK fields.
+
+`audit: true` on an **entity** adds the four standard audit columns (`CreatedAt`, `CreatedBy`, `UpdatedAt`, `UpdatedBy`), populated by the platform's audit annotations.
+
+### Calculated fields
+
+A field value can be derived on insert / update instead of being entered:
+
+- **`calculatedOnCreate` / `calculatedOnUpdate`** - an expression the generated repository assigns to the property. Prefer a **neutral arithmetic expression** for numeric totals (`"Quantity * Price"`, `"round(Net * 0.2, 2)"`): the SDK `Calc` evaluator runs it on the server and the UI previews it live with the same evaluator. A non-numeric field's expression is emitted verbatim, so it must be valid Java for the Java DAO (e.g. `"java.util.UUID.randomUUID().toString()"`).
+- **`calculatedActionOnCreate` / `calculatedActionOnUpdate`** - a server-side call-out for logic too custom to model (conditional / sequential number generation, lookups). The value names a Java class - a `@Component` implementing `org.eclipse.dirigible.sdk.db.CalculatedField<E, T>` (`T calculate(E entity)`) - that the repository invokes via `Beans.get(<class>.class).calculate(entity)`. It runs **server-side only** (no live preview) and **takes precedence** over the expression on the same slot. The implementation is hand-written by you under `custom/` (never `gen/`); the intent emits no Java.
+
+To reference an action class by simple name, the entity declares `imports:` - a multi-line string of Java `import ...;` lines injected verbatim into the generated repository:
+
+```yaml
+entities:
+  - name: SalesInvoice
+    imports: |
+      import custom.sales_invoices.SalesInvoiceNumberAction;
+    fields:
+      - { name: number, type: string, length: 100, calculatedActionOnCreate: SalesInvoiceNumberAction }
+```
+
+You then add `custom/sales_invoices/SalesInvoiceNumberAction.java`. Alternatively give the fully-qualified class name and omit the import.
 
 ### relations
 
@@ -151,6 +177,43 @@ Composition is **opt-in** - this matches the Dirigible convention where most req
 ```
 
 `kind: setting` marks an entity as nomenclature / configuration. It is generated with `type="SETTING"`, which the template engine routes under the dashboard's global **Settings** perspective instead of giving it its own perspective. Any relation **targeting** a setting entity resolves its dropdown to the `Settings` perspective. Settings are still real entities (own table, seeds, FK columns) - only their UI placement differs. Default `kind` (omitted) is a regular managed entity.
+
+### Cross-model references (`uses`)
+
+A relation can target an entity owned by a **different** project's intent model - master / reference data (`Customer`, `Country`, `Currency`, `UoM`) you do not want to redefine. The owner model owns the single table; this model stores an integer FK and renders a dropdown sourced from the owner's REST service. It does **not** generate the owner's table or API.
+
+Declare the dependencies in a top-level `uses:` block, then point a `manyToOne` / `oneToOne` relation at the alias with `model:`:
+
+```yaml
+name: customers
+uses:
+  - { model: countries }                        # project defaults to the model alias
+  - { model: currencies, project: currencies }   # set project when it differs from the alias
+entities:
+  - name: Customer
+    fields:
+      - { name: id,   type: integer, primaryKey: true, generated: true }
+      - { name: name, type: string,  required: true }
+    relations:
+      - { name: Country,  kind: manyToOne, to: Country,  model: countries }
+      - { name: Currency, kind: manyToOne, to: Currency, model: currencies }
+```
+
+A cross-model relation must be `manyToOne` / `oneToOne`, its `model:` must be listed in `uses:`, and it **cannot** be `composition: true` (a detail cannot be owned across models). Generate the owner (leaf) models before their consumers so the dropdown resolves; each project is its own `.intent` and all must be published to the same runtime. Under the hood this reuses the platform's PROJECTION mechanism.
+
+### Many-to-many
+
+There is no `manyToMany` materialisation. Model n:m as an **explicit intermediate entity** holding a `composition` to one side, a `manyToOne` to the other (which may be cross-model via `model:`), plus any bridge fields:
+
+```yaml
+  - name: SalesInvoiceCustomerPayment
+    fields:
+      - { name: id,     type: integer, primaryKey: true, generated: true }
+      - { name: amount, type: decimal, precision: 18, scale: 2, required: true }   # partial allocation
+    relations:
+      - { name: SalesInvoice,    kind: manyToOne, to: SalesInvoice,    composition: true, required: true }
+      - { name: CustomerPayment, kind: manyToOne, to: CustomerPayment, model: customer-payments, required: true }
+```
 
 ## processes
 

--- a/docs/help/intent/multi-model.md
+++ b/docs/help/intent/multi-model.md
@@ -1,0 +1,146 @@
+---
+title: Multi-model applications
+description: Split a domain into several intent projects that reference each other across models, reuse single master-data entities, and contribute their screens to one shared application shell.
+---
+
+# Multi-model applications
+
+A non-trivial domain is rarely one project. The intent layer lets you split it into **several intent projects** - one `*.intent` per project, each the source of truth for its own slice - that **reference each other across models**, **reuse** single master-data entities instead of redefining them, and **contribute** their screens to one **shared application shell**.
+
+In practice each module is its **own repository**, versioned and shipped independently as a build artefact (an npm module), and consumed by others as a dependency - so a `currencies` or `customers` module is published once and reused across many applications. The worked example below keeps all the modules in **one repository for simplicity** (so you can clone and try the whole domain in one step), but nothing about the model requires that: each subfolder is a self-contained project that could equally live in its own repo and be pulled in as a dependency.
+
+The worked example is [`dirigiblelabs/sample-intent-multi-model`](https://github.com/dirigiblelabs/sample-intent-multi-model): a Billing domain in six intent projects plus one navigation project, collected in a single repository for convenience.
+
+| Project | Owns | References (cross-model) |
+| --- | --- | --- |
+| `uoms` | Dimension, UoM | - |
+| `countries` | Country | - |
+| `currencies` | Currency, CurrencyRate | - |
+| `customers` | Customer | Country, Currency |
+| `customer-payments` | CustomerPayment | Customer, Currency |
+| `sales-invoices` | SalesInvoice, SalesInvoiceItem, SalesInvoiceCustomerPayment, settings | Customer, Currency, UoM, CustomerPayment |
+| `navigation` | (no intent) the shared-shell groups | - |
+
+## Reuse, don't redefine - one master-data entity
+
+Master / reference data (`Customer`, `Country`, `Currency`, `UoM`) is owned by **one** project. Every other project that needs it stores an **integer FK** and renders a dropdown sourced from the **owner's** REST service - it does **not** generate the owner's table or API. There is one `Country` table, one `Customer` table, one place to change them.
+
+Declare the dependency in a top-level `uses:` block, then point a `manyToOne` / `oneToOne` relation at the alias with `model:`:
+
+```yaml
+name: customers
+uses:
+  - { model: countries }
+  - { model: currencies }
+entities:
+  - name: Customer
+    relations:
+      - { name: Country,  kind: manyToOne, to: Country,  model: countries }
+      - { name: Currency, kind: manyToOne, to: Currency, model: currencies }
+```
+
+A cross-model relation must be `manyToOne` / `oneToOne`, its `model:` must be listed in `uses:`, and it **cannot** be a `composition` (a detail cannot be owned across models). The mechanism is the platform's PROJECTION: the consumer's `.model` carries a projection of the owner entity so the FK dropdown resolves against the owner's live service. `project:` defaults to the model alias, so when the project folder name equals the intent `name:` you omit it; set it when they differ:
+
+```yaml
+uses:
+  - { model: currencies, project: currencies }   # only needed when alias != project name
+```
+
+See [cross-model references in the `.intent` file](/help/intent/intent-file#cross-model-references-uses) for the full rules.
+
+### Many-to-many across models
+
+`SalesInvoice` (in `sales-invoices`) is settled by many `CustomerPayment`s (in `customer-payments`), and a payment spans many invoices. Model it as an **explicit intermediate entity** with a local `composition` to one side and a cross-model `manyToOne` to the other, carrying the bridge field:
+
+```yaml
+- name: SalesInvoiceCustomerPayment
+  fields:
+    - { name: id,     type: integer, primaryKey: true, generated: true }
+    - { name: amount, type: decimal, precision: 18, scale: 2, required: true }
+  relations:
+    - { name: SalesInvoice,    kind: manyToOne, to: SalesInvoice,    composition: true, required: true }
+    - { name: CustomerPayment, kind: manyToOne, to: CustomerPayment, model: customer-payments, required: true }
+```
+
+## One shared shell - contributions, not app-hopping
+
+Each domain project generates its **own** standalone app shell (handy to run or test one domain in isolation at `/services/web/<project>/gen/<genFolder>/index.html`). They **also** contribute their entities as grouped perspectives to the platform's **shared** application shell at **`/services/web/application/`** - one app with a single grouped sidebar, every screen embedded in the one shell so the user never jumps between per-project UIs.
+
+Two pieces drive this:
+
+**1. `group:` on an entity** places its generated perspective under a named navigation group in the shared shell:
+
+```yaml
+entities:
+  - name: Customer
+    group: partners        # appears under the "Partners" group in the shared shell
+```
+
+The entity only references the group **id**. A `group:` does not affect the project's own standalone shell.
+
+**2. A navigation project defines each group once.** Group ids are declared in one dedicated project (not an intent project) so they are not redeclared per domain - the shell drops duplicate group ids. Each group is a module exporting `getPerspectiveGroup()`, registered on the `application-perspectives` extension point:
+
+```js
+// navigation/configs/sales.js
+exports.getPerspectiveGroup = () => ({
+  id: 'sales',
+  label: 'Sales',
+  expanded: true,
+  order: 20,
+  icon: '/services/web/resources/unicons/receipt.svg',
+  items: []
+});
+```
+
+```json
+// navigation/extensions/sales.extension
+{
+  "module": "navigation/configs/sales.js",
+  "extensionPoint": "application-perspectives",
+  "description": "Navigation group - Sales"
+}
+```
+
+The domain entities then reference these ids (`group: sales`, `group: settings`, ...). The shared shell aggregates every contributed perspective into its sidebar under the matching group, ordered by each group's `order`.
+
+## Packaging in practice - separate repositories
+
+The sample puts every module in one repository so the whole domain clones in one step. A real system ships each module **independently**:
+
+- Each module is its **own repository**, with its own release cadence and version. A reusable module like `currencies` or `countries` is published once and consumed by many applications.
+- Modules are distributed as **build artefacts (npm modules)** and pulled in as dependencies, the same way any reusable library is. A consuming module declares what it depends on in its `package.json`:
+
+  ```json
+  {
+    "name": "customers",
+    "version": "1.0.0",
+    "dependencies": {
+      "countries": "^1.0.0",
+      "currencies": "^1.0.0"
+    }
+  }
+  ```
+
+  `npm install` pulls the owner modules in, and they are deployed into the registry alongside the consumer.
+
+- The `uses:` block in the consumer's intent names the same owner models; the installed dependency makes the owner's published artefacts (its `.model` + REST service) available at generation and runtime. (In the single-repo sample the projects are siblings already in the workspace, so nothing needs installing.)
+
+So the only difference between the single-repo sample and a production setup is **where the projects live** - the cross-model `uses:` / `model:` references, the shared-shell `group:` contributions, and the generate-then-publish flow are identical either way.
+
+## Generate leaf-first, then publish everything
+
+Cross-model dropdowns read the **owner's already-generated `.model`** at generation time and call the **owner's live REST service** at runtime, so order matters:
+
+1. **Generate the owners (leaves) first**, then their consumers. For the sample: `uoms` / `countries` / `currencies`, then `customers`, then `customer-payments`, then `sales-invoices`. (The `navigation` project has no intent - it just declares the groups and is published as-is.)
+2. **Publish everything.** Every owner project must be live for a consumer's cross-model dropdown to resolve, and the `.csvim` seeds load the nomenclatures.
+3. **Open `/services/web/application/`** - the shared shell with the grouped sidebar (Master Data / Sales / Payments / Settings).
+
+Each project is its own `.intent`; the project folder name equals the intent `name:` (and so the table prefix and gen folder). Because table names are [intent-prefixed](/help/intent/intent-file#naming-and-tables) (`<INTENT>_<ENTITY>`), the projects share a schema without colliding.
+
+## See also
+
+- [The `.intent` file](/help/intent/intent-file) - cross-model `uses:`, many-to-many, field attributes
+- [Generators and generation](/help/intent/generators)
+- [Harmonia runtime UI](/help/develop/harmonia-runtime-ui) - the default code-gen UI stack for the sample
+- [Extensibility](/help/concepts/extensibility) - the extension-point model behind `application-perspectives`
+- [`dirigiblelabs/sample-intent-multi-model`](https://github.com/dirigiblelabs/sample-intent-multi-model)


### PR DESCRIPTION
## What

New page **`/help/intent/multi-model`** documenting the multi-module intent approach demonstrated by [`dirigiblelabs/sample-intent-multi-model`](https://github.com/dirigiblelabs/sample-intent-multi-model).

Covers:
- **Reuse of single master-data entities** - cross-model `uses:` + relation `model:`: one owner table, consumers store an integer FK + dropdown sourced from the owner's REST service (no duplicated table), PROJECTION-backed.
- **Many-to-many across models** via an explicit intermediate entity (local `composition` to one side, cross-model `manyToOne` to the other, plus bridge fields).
- **One shared application shell** at `/services/web/application/` - `group:` on entities + a `navigation` project's `getPerspectiveGroup()` contributions on the `application-perspectives` extension point; per-project standalone shells still available.
- **Packaging in practice** - each module is normally its own repository, shipped as an **npm module** and pulled in as a `package.json` dependency; the sample collapses them into one repo for convenience. The model/contribution/flow are identical either way.
- **Generate leaf-first, then publish everything** so cross-model references resolve.

Wired into the Intent sidebar and the section index.

## Verification
- `npm run docs:build` passes clean.
- Content cross-checked against the sample repo (READMEs, the six `*.intent` files, the `navigation` configs/extensions, and `SalesInvoiceNumberAction.java`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)