### PR TITLE
docs(artefacts): list model artefacts (.intent/.glue/.edm/.form/.report)

### DIFF
--- a/docs/help/artefacts/index.md
+++ b/docs/help/artefacts/index.md
@@ -22,6 +22,17 @@ Files placed under a project are reconciled into runtime state by **synchronizer
 - **[View](/help/artefacts/data/view)** - `*.view`
 - **[CSV import model](/help/artefacts/data/csvim)** - `*.csvim` + `*.csv`
 
+## Modeling
+
+Design-time models. Generation turns them into the runtime artefacts on this page (and the code under `gen/`).
+
+- **[Intent](/help/intent/intent-file)** - `*.intent` (the whole application in one YAML file; generates the models below)
+- **[Declarative glue](/help/intent/glue)** - `*.glue` (annotated client-Java: `@Listener` / `@Scheduled` / `@Controller`, generated from the intent)
+- **[Entity Data Model](/help/ide/modelers/entity-data)** - `*.edm` + `*.model`
+- **[Database schema model](/help/ide/modelers/database-schema)** - `*.dsm`
+- **[Form](/help/ide/modelers/form-designer)** - `*.form`
+- **[Report](/help/ide/editors/report)** - `*.report`
+
 ## Process
 
 - **[BPMN](/help/artefacts/process/bpmn)** - `*.bpmn`


### PR DESCRIPTION
The [Artefacts](/help/artefacts/) landing page listed scripting/data/process/services/security/extensibility/docs extensions but omitted the **design-time model artefacts**. Adds a **Modeling** section linking each to its editor/modeler:

- `*.intent` -> Intent file reference
- `*.glue` -> declarative glue
- `*.edm` + `*.model` -> Entity Data modeler
- `*.dsm` -> Database Schema modeler
- `*.form` -> Form Designer
- `*.report` -> Report editor

All targets already exist (and `reference/artefact-extensions.md` already listed these). Build clean; no em/en-dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)