### PR TITLE
blog: intent-driven development series (4 posts)

### DIFF
--- a/docs/blogs/2026/07/01/intent-driven-sales-invoices.md
+++ b/docs/blogs/2026/07/01/intent-driven-sales-invoices.md
@@ -1,0 +1,148 @@
+---
+title: "From Prompt to Running App: Intent-Driven Development with Eclipse Dirigible"
+description: "A hands-on walkthrough of building a complete Sales Invoices application from a single intent file - entities, a calculated document, an approval workflow and a modern UI, with the AI assistant doing the heavy lifting."
+author: Nedelcho Delchev
+author_gh_user: delchev
+author_avatar: https://avatars.githubusercontent.com/u/6852373?v=4
+read_time: 9 min
+publish_date: July 1, 2026
+---
+
+Most application platforms ask you to model first, then wire, then build a UI, then write the glue. [Eclipse Dirigible](https://www.dirigible.io/) now lets you work **one altitude higher**: you describe the application you want in a single **intent** file, and the platform generates the data model, the persistence, the REST APIs, the UI and the workflow for you.
+
+In this article we build a real **Sales Invoices** application end to end - from an empty project to a running app with an approval workflow - without hand-writing CRUD, REST or UI code. The finished sample lives at [`sample-intent-model`](https://github.com/dirigiblelabs/sample-intent-model).
+
+## The three altitudes
+
+The idea you need to grok first: there are three levels, and you author only the top one.
+
+| Altitude | Artefact | Authored by |
+| --- | --- | --- |
+| 1 - Intent | one `*.intent` file | you (and the AI assistant) |
+| 2 - Models | `.edm` / `.bpmn` / `.form` / `.report` / `.roles` / `.csvim` | generated from the intent |
+| 3 - Application | schema, persistence, REST, UI, jobs, processes | generated from the models |
+
+You edit the intent; the platform deterministically produces everything below it. Change a line, regenerate, and the whole stack follows.
+
+## The scenario
+
+A classic billing document: a **Sales Invoice** with a customer, a currency, line items, calculated totals, and a lifecycle - an invoice is drafted, **approved**, **issued** and **sent** (or rejected). That is exactly the kind of regulated, auditable, multi-step process Eclipse Dirigible is built for.
+
+## Step 1 - Create the project and the intent
+
+In the Dirigible web IDE, create a project and add a file `sales-invoices.intent` at its root. You can type the YAML by hand, but the faster path is to **prompt the AI assistant** built into the Intent Editor. Open the assistant pane and describe what you want:
+
+> "A Sales Invoice with a customer, currency, line items (name, quantity, price, discount), and calculated Net, Vat and Total per line. Add an approval process: approve, then issue, then send, with a reject branch that cancels."
+
+The assistant proposes a complete `app.intent` as a **diff** against your buffer. You review it, click **Accept**, and the editor's live diagram updates instantly.
+
+## Step 2 - The intent, in plain YAML
+
+What the assistant produces (and what you can refine by hand) is readable and compact. The document entity and its line items:
+
+```yaml
+name: sales-invoices
+entities:
+  - name: SalesInvoice
+    audit: true
+    fields:
+      - { name: id, type: integer, primaryKey: true, generated: true }
+      - { name: number, type: string, length: 100 }
+      - { name: date, type: date, required: true }
+      - { name: net,   type: decimal, precision: 18, scale: 2, aggregate: true }
+      - { name: vat,   type: decimal, precision: 18, scale: 2, aggregate: true }
+      - { name: total, type: decimal, precision: 18, scale: 2, aggregate: true }
+    relations:
+      - { name: Customer, kind: manyToOne, to: Customer, required: true }
+  - name: SalesInvoiceItem
+    fields:
+      - { name: id, type: integer, primaryKey: true, generated: true }
+      - { name: quantity, type: decimal, precision: 18, scale: 3, required: true }
+      - { name: price,    type: decimal, precision: 18, scale: 2, required: true }
+      - { name: discount, type: decimal, precision: 18, scale: 2 }
+      - { name: net,   type: decimal, calculatedOnCreate: "Quantity * Price",        calculatedOnUpdate: "Quantity * Price" }
+      - { name: vat,   type: decimal, calculatedOnCreate: "round(Net * 0.2, 2)",      calculatedOnUpdate: "round(Net * 0.2, 2)" }
+      - { name: total, type: decimal, calculatedOnCreate: "Net + Vat - Discount",     calculatedOnUpdate: "Net + Vat - Discount" }
+    relations:
+      - { name: SalesInvoice, kind: manyToOne, to: SalesInvoice, composition: true, required: true }
+```
+
+Two things worth noticing:
+
+- **`composition: true`** makes `SalesInvoiceItem` a *detail* of `SalesInvoice` - the platform generates a master-detail screen where items are managed inside the invoice.
+- **Calculated fields** (`Net = Quantity * Price`, ...) are evaluated on the server and previewed live in the UI with the same evaluator. No event handlers to write.
+
+The line totals roll up to the invoice header automatically because the header's `net` / `vat` / `total` are marked `aggregate: true`.
+
+## Step 3 - Status, the document way
+
+The invoice has a `Status` relation to a `SalesInvoiceStatus` nomenclature (DRAFT, APPROVED, ISSUED, SENT, CANCELLED). Two small flags make it behave like a real business document:
+
+```yaml
+relations:
+  - { name: Currency,      kind: manyToOne, to: Currency, size: 4 }
+  - { name: Status,        kind: manyToOne, to: SalesInvoiceStatus, documentStatus: true, init: 1 }  # 1 = DRAFT
+  - { name: PaymentMethod, kind: manyToOne, to: PaymentMethod, init: 2, size: 4 }                    # 2 = Bank transfer
+  - { name: SentMethod,    kind: manyToOne, to: SentMethod, init: 1, size: 4 }                       # 1 = E-mail
+```
+
+- **`init: 1`** sets the foreign key's **database-level default** - a new invoice starts as DRAFT the instant it is inserted, without any code or a workflow step. That matters: setting the initial status from a process step would race the trigger that starts the process. The FK default is race-free.
+- **`documentStatus: true`** tells the generated UI to render this relation as a **status pill** in the document header; the matching **`documentTitle: true`** on the `number` field renders it as the document title.
+- **`size: 4`** is the form-control width as a **12-column grid span** (3 = quarter, 4 = third, 6 = half, 12 = full). A control without a `size` takes half the row; giving Currency, PaymentMethod and SentMethod a third each packs the three short pickers onto a single row instead of three half-empty ones. It works on plain fields too.
+
+## Step 4 - The workflow, declared in the same file
+
+The lifecycle is a process that starts when an invoice is created and walks Approve -> Issue -> Send:
+
+```yaml
+processes:
+  - name: SalesInvoiceApproval
+    trigger: { onCreate: SalesInvoice }
+    steps:
+      - { name: approve,         kind: userTask,    args: { assignee: approver, form: ApproveSalesInvoice } }
+      - { name: approveDecision, kind: decision,    args: { if: "action == 'approve'", then: activate, else: cancel } }
+      - { name: activate,        kind: serviceTask, args: { setRelationField: Status, value: 2, next: issue } }   # APPROVED
+      - { name: issue,           kind: userTask,    args: { assignee: issuer, form: IssueSalesInvoice, setRelationField: Status, value: 3, next: send } }  # ISSUED
+      - { name: send,            kind: userTask,    args: { assignee: sender, form: SendSalesInvoice,  setRelationField: Status, value: 4, next: end } }   # SENT
+      - { name: cancel,          kind: serviceTask, args: { setRelationField: Status, value: 5, next: end } }      # CANCELLED
+      - { name: end,             kind: end }
+```
+
+Status transitions use **`setRelationField: Status, value: N`** - a step sets the status foreign key to a nomenclature seed id, with no hand-written handler. The APPROVED transition sits on the *approve branch* (the `activate` service task), so a **Reject** goes straight to CANCELLED without passing through APPROVED. That is the whole BPMN process - human tasks, a decision gateway, status transitions - declared in place. The Intent Editor renders it as a flow diagram next to the YAML so you can read the branching at a glance.
+
+> 📸 *Screenshot: the Intent Editor - YAML on the left, the live entity + process diagram on the right.*
+
+## Step 5 - Generate
+
+Click **Generate**. The platform writes the model files next to your intent, then chains the model-to-code generation: a Java persistence layer, REST controllers, a **modern Harmonia single-page UI**, the BPMN process, the forms, the report pages, and the seed data. Publish, and the app is live.
+
+## Step 6 - Run the lifecycle
+
+Open the generated app and walk the flow:
+
+1. **New invoice** - fill the header (number starts as a draft placeholder, date, customer). The status pill reads **DRAFT** (the FK default) and totals are 0; there are no items yet.
+2. **Create** - saving the header reveals the line-items table *and* starts the approval process, creating an **Approve** task.
+3. **Add items** - pick a **product**: the unit list narrows to the product's base UoM and auto-selects it, and the price pre-fills with the product's default (both still editable). Enter the quantity; `Net`, `Vat`, `Total` compute live, and the header totals recompute.
+4. **Approve** - open the task from the built-in **Process Inbox**, review the read-only card, and click **Approve** (or **Reject** to cancel).
+5. **Issue**, then **Send** - the invoice walks to its final state; at Issue it also gets its definitive sequential number (e.g. `SI00000001`) and any of the customer's open payments are auto-allocated, moving the status to **PARTIAL** or **PAID**.
+6. **Preview** - every record also has a read-only view (a **Preview** button next to Edit, its own shareable `/preview` URL): the same document, items and totals with nothing editable - right for reviewers who should look but not touch.
+
+The product-driven pre-fill (Depends-On), the payment roll-up and the auto-allocation are covered in the [documents-that-settle-themselves](../04/documents-that-settle-themselves.md) follow-up; the number generator in the [multi-model](../02/composing-a-business-suite.md) and [custom-Java](../03/custom-java-in-the-web-ide.md) ones.
+
+> 📸 *Screenshot: the running Harmonia app - the invoice document with line items and the Process Inbox.*
+
+## What just happened
+
+You wrote one YAML file. You did **not** write a single line of CRUD, SQL, REST routing, UI markup or BPMN XML. The calculated totals, the master-detail screen, the approval workflow, the task forms and the seed data all came from the intent - and they regenerate deterministically every time you change it.
+
+That is the Eclipse Dirigible promise: describe the application at the altitude of *intent*, and let the platform build the rest.
+
+## Where next
+
+This single-module app is the foundation for three follow-ups:
+
+- **Composing a business suite** - splitting customers, currencies and units of measure into reusable modules that many apps share, with one shared application shell.
+- **Documents that settle themselves** - payment allocation with automatic roll-ups, cascading Depends-On forms, and management reports that join across modules.
+- **Custom Java when the model isn't enough** - dropping a hand-written calculation into the generated app without leaving the browser.
+
+Explore the finished sample at [`sample-intent-model`](https://github.com/dirigiblelabs/sample-intent-model), and see the whole [Eclipse Dirigible platform](https://www.dirigible.io/) for what else it can build.

--- a/docs/blogs/2026/07/02/composing-a-business-suite.md
+++ b/docs/blogs/2026/07/02/composing-a-business-suite.md
@@ -1,0 +1,153 @@
+---
+title: "Composing a Business Suite: Reusable Master Data and One Shared Shell"
+description: "How to split a billing domain into independent Dirigible modules that reference each other across models, reuse single master-data entities instead of duplicating them, and come together into one shared application shell."
+author: Nedelcho Delchev
+author_gh_user: delchev
+author_avatar: https://avatars.githubusercontent.com/u/6852373?v=4
+read_time: 7 min
+publish_date: July 2, 2026
+---
+
+In the [previous article](../01/intent-driven-sales-invoices.md) we built a Sales Invoices app from a single intent file. That app defined its own `Customer` and `Currency`. In a real system, though, customers and currencies are **shared** - used by invoices, by payments, by orders, by a dozen apps. You do not want a copy of the `Currency` table in each one.
+
+This article shows how [Eclipse Dirigible](https://www.dirigible.io/) composes a domain out of **independent modules** that reference each other across models, reuse one master-data table everywhere, and assemble into **one shared application shell**. The complete suite lives in the single [sample-intent-multi-model](https://github.com/dirigiblelabs/sample-intent-multi-model) repository, one folder per module.
+
+## The suite
+
+A Billing domain, split into one module per concern - each a folder in the repository, each a single intent file:
+
+| Module | Owns | References (cross-model) |
+| --- | --- | --- |
+| `uoms` | UoM | - |
+| `countries` | Country, City | - |
+| `currencies` | Currency, CurrencyRate | - |
+| `numbers` | Number series + reusable generator | - |
+| `products` | Product | UoM |
+| `customers` | Customer | Country, Currency |
+| `customer-payments` | CustomerPayment | Customer, Currency |
+| `sales-invoices` | SalesInvoice, items, allocations | Customer, Currency, UoM, CustomerPayment, Product, Numbers |
+| `navigation` | the shared-shell groups | - |
+
+## Reuse, don't redefine
+
+Master data - `Customer`, `Country`, `Currency`, `UoM` - is owned by **one** module. Every other module that needs it stores an **integer foreign key** and renders a dropdown sourced from the **owner's** REST service. There is one `Currency` table, one place to change it.
+
+A consumer declares what it depends on in a top-level `uses:` block, then points a relation at the owner with `model:`:
+
+```yaml
+name: customers
+uses:
+  - { model: countries }
+  - { model: currencies }
+entities:
+  - name: Customer
+    relations:
+      - { name: Country,  kind: manyToOne, to: Country,  model: countries }
+      - { name: Currency, kind: manyToOne, to: Currency, model: currencies }
+```
+
+The `customers` module never generates a `Country` table or API - it just links to the one `countries` owns. Change `Country` once, and every consumer sees it.
+
+### Data is data - keep it out of the model
+
+Reference data comes in two sizes, and the intent treats them differently. Small sets whose values are part of the flows (statuses, payment methods) stay **inline** as seed rows. Everything bulkier - the 249-row ISO 3166 country list, the currency table, and all the prepopulated demo data (customers, products, the sample invoices and their items) - lives in authored CSVs, and the seed just points at the file:
+
+```yaml
+seeds:
+  - name: countries
+    entity: Country
+    file: data/countries.csv
+```
+
+The intent stays lean (the countries model shrank from 272 lines to 49), each `data/*.csv` is owned and versioned by the developer, and only the import artefact is generated. Every module in the suite now keeps its prepopulated data this way.
+
+### Speak the user's language
+
+Master data is also where translations live. The `uoms` module declares its `UoM` entity `multilingual: true` and lists the app's data languages:
+
+```yaml
+languages: [en, bg]
+entities:
+  - name: UoM
+    multilingual: true
+seeds:
+  - name: uoms-bg
+    entity: UoM
+    language: bg
+    rows:
+      - { id: 8,  name: "Килограм" }
+      - { id: 19, name: "Литър" }
+```
+
+Three things follow, none of them hand-written: the schema gains a language table for the translated names; every read overlays the caller's language onto the base values (a unit without a translation keeps its English name); and the shared shell gains a **Region & Language** setting - pick Bulgarian there and every dropdown, list and document that shows a unit of measure reads `Килограм` instead of `Kilogram`, across **all** the modules that reuse it. Translate the master data once, in the module that owns it, and the whole suite speaks the language.
+
+And not only the data: the **UI itself translates through the same switch**. Generation emits a translation catalog per module with every label the screens use - buttons, messages, field labels, and the entity display names in both their forms: the humanized singular (`Sales Invoice`, for form captions and "New X") and the humanized plural (`Sales Invoices`, for the sidebar, list titles and detail panels) as separate keys, so a translator can render them properly (`Фактура за продажба` / `Фактури за продажба` - one key could never be both). Add a Bulgarian catalog next to the generated English one and the sidebar, the shared shell's tiles and every generated screen follow the Region & Language setting; anything untranslated gracefully stays English.
+
+### Reuse code, too
+
+Modules can own reusable *logic*, not just reference tables: **`numbers`** owns a `Number` series entity plus a small reusable `DocumentNumberGenerator`, and the invoice's process calls it (via a `delegate` service task) to stamp `SI00000001`-style numbers. One number generator, reused by every document module in the suite - see the [custom-Java post](../03/custom-java-in-the-web-ide.md) for how that delegate is written.
+
+## Documents that work together
+
+Composition is not only about *referencing* another module's data - the documents also **behave** across module boundaries: an invoice is settled by payments through a cross-model n:m with automatic paid/balance/status roll-ups, the allocation forms guide the user with cascading Depends-On controls, and management reports join the customers' and products' tables for their names. Those are the subject of the [next post in the series](../04/documents-that-settle-themselves.md) - here it is enough to know that all of them are declared in the same intent files, and none of them break the module independence described above.
+
+## One shared shell - no app-hopping
+
+Each module generates its **own** standalone app, which is handy for running or testing one concern in isolation. But they also **contribute** their screens to one shared application shell, so users never jump between per-module UIs.
+
+Two pieces drive this. First, each entity names the navigation group it belongs to:
+
+```yaml
+entities:
+  - name: Customer
+    group: partners        # appears under "Partners" in the shared shell
+```
+
+Second, a dedicated `navigation` module declares each group **once** (so it is not redeclared per module), as a small contribution on the platform's `application-perspectives` extension point:
+
+```js
+// navigation/configs/sales.js
+exports.getPerspectiveGroup = () => ({
+  id: 'sales', label: 'Sales', expanded: true, order: 20,
+  icon: '/services/web/resources/unicons/receipt.svg', items: []
+});
+```
+
+Publish the suite and open the shared shell at `/services/web/application/`: one app, one grouped sidebar - **Partners**, **Sales**, **Payments**, **Settings** - every screen embedded in the one shell.
+
+> 📸 *Screenshot: the shared shell with the grouped sidebar aggregating all modules.*
+
+## Packaging in practice
+
+In the sample, every module is a folder in one repository for convenience. In a real system each module would be its **own repository**, versioned and shipped independently as an **npm module** and consumed by others as a dependency. A consuming module declares what it needs in its `package.json`:
+
+```json
+{
+  "name": "@dirigiblelabs/customers",
+  "version": "1.0.0",
+  "dependencies": {
+    "@dirigiblelabs/countries": "^1.0.0",
+    "@dirigiblelabs/currencies": "^1.0.0"
+  }
+}
+```
+
+`npm install` pulls the owner modules in, and they deploy into the runtime alongside the consumer. A reusable module like `currencies` is published once and reused across many applications - the cross-model `uses:` reference resolves against whatever owner is installed.
+
+## Generate and publish
+
+A consumer resolves its cross-model references against the owner's model - and the platform resolves them **order-independently**, falling back to the **registry** as a first-class source when an owner is not open in your workspace. So you no longer have to generate strictly leaf-first; if an owner cannot be resolved at all, generation **fails loudly** with a clear message rather than producing a broken dropdown.
+
+A natural order is still the simplest mental model:
+
+1. Generate the owners (leaves): `uoms`, `countries`, `currencies`, `numbers`.
+2. Then `customers` and `products`, then `customer-payments`, then `sales-invoices`.
+3. Publish everything (the `navigation` module too) and open `/services/web/application/`.
+
+At runtime the cross-model dropdowns call the owner module's live REST service, so every owner must be **published** - but the *generation* order between them is now flexible.
+
+## The payoff
+
+Build a piece of master data **once**; reuse it everywhere; compose independently-shipped modules into one coherent application. That is how Dirigible scales from a single app to an enterprise suite without duplication - and the whole suite is there to clone: [sample-intent-multi-model](https://github.com/dirigiblelabs/sample-intent-multi-model).
+
+Next in the series: [how the documents behave across those module boundaries](../04/documents-that-settle-themselves.md) - payment allocation with roll-ups, cascading forms, and cross-module reports.

--- a/docs/blogs/2026/07/03/custom-java-in-the-web-ide.md
+++ b/docs/blogs/2026/07/03/custom-java-in-the-web-ide.md
@@ -1,0 +1,126 @@
+---
+title: "When the Model Isn't Enough: Custom Java in the Web IDE"
+description: "Low-code where you can, real code where you must. How to drop a hand-written Java calculation into a generated Dirigible application using calculated-field actions and the IntelliJ-grade Java tooling in the web IDE - without leaving the browser."
+author: Iliyan Velichkov
+author_gh_user: iliyan-velichkov
+author_avatar: https://avatars.githubusercontent.com/u/5058839?v=4
+read_time: 5 min
+publish_date: July 3, 2026
+---
+
+Model-driven platforms live or die by their **escape hatch**. Ninety percent of an application is CRUD, forms, dropdowns and workflows that you should never hand-write - and the [Eclipse Dirigible](https://www.dirigible.io/) intent layer generates exactly that. But every real system has the other ten percent: a calculation, an integration, a rule that no model can express. The question is whether the platform lets you write it cleanly, or forces you to fight it.
+
+In this article we take the generated `sales-invoices` module from the [multi-module sample](https://github.com/dirigiblelabs/sample-intent-multi-model) - the same one built in the [first post in this series](../01/intent-driven-sales-invoices.md) - and replace one piece of logic - the invoice **number generation** - with hand-written Java, using the full IDE tooling, without leaving the browser.
+
+## The boundary: model vs. code
+
+The intent owns three folders, each with a clear owner:
+
+| Folder | Owned by | Lifecycle |
+| --- | --- | --- |
+| the `*.intent` | you | the only authored model artefact |
+| `gen/` | the platform | wiped and regenerated on every Generate |
+| `custom/` | you | the escape hatch - touched by nobody |
+
+Anything you hand-write goes in `custom/`. It survives regeneration. The model declares a hook; your code supplies the implementation.
+
+## The hook: a calculated-field action
+
+Line totals (`Net = Quantity * Price`) are neutral arithmetic - a one-line calculated expression in the intent, evaluated on the server and previewed live. But the invoice **number** is different: in a real deployment it comes from a number-series service with prefixes and sequences. That is logic, not arithmetic.
+
+The intent declares the field as a **calculated action** and imports the class that will implement it:
+
+```yaml
+- name: SalesInvoice
+  imports: |
+    import custom.sales_invoices.SalesInvoiceNumberAction;
+  fields:
+    - { name: number, type: string, length: 100, calculatedActionOnCreate: SalesInvoiceNumberAction }
+```
+
+`calculatedActionOnCreate` names a Java class; the generated repository will call `Beans.get(SalesInvoiceNumberAction.class).calculate(entity)` whenever an invoice is created. The model says *what* runs; you write *how*.
+
+## The implementation
+
+Under `custom/`, write the class:
+
+```java
+package custom.sales_invoices;
+
+import java.util.UUID;
+
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.db.CalculatedField;
+
+@Component
+public class SalesInvoiceNumberAction implements CalculatedField<Object, String> {
+
+    @Override
+    public String calculate(Object entity) {
+        return UUID.randomUUID().toString();
+    }
+}
+```
+
+`@Component` makes it a managed bean; `CalculatedField<E, T>` is the one-method contract the repository invokes. Here it returns a UUID so the sample runs without an external service - swap in a real number-series call and nothing in the model changes.
+
+## The tooling: IntelliJ-grade Java in the browser
+
+This is where the Dirigible web IDE earns its keep. Editing that class, you get full **JDT language-server** support directly in the browser:
+
+- completion, hover and signature help over the platform SDK
+- **go to definition** and **peek references** across your code and the SDK
+- rename and other refactorings
+- live diagnostics as you type
+- breakpoints and step-debugging through the Java debugger
+
+Client Java is compiled **in-process** - one `javac` task per synchronization cycle, sharing the JVM with the platform - so `Beans.get(...)` resolves real platform beans and your class is live at the next request.
+
+> 📸 *Screenshot: the web IDE editing the Java action - completion popup over the SDK, Problems view clean.*
+
+## A reusable escape hatch: a workflow delegate
+
+A calculated field is one hook; a **BPM `delegate` service task** is another. In the finished sample the invoice's *definitive* number (`SI00000001`) is stamped after the Issue step, not on create. The process declares a delegate step:
+
+```yaml
+- name: generateNumber
+  kind: serviceTask
+  args:
+    delegate: custom.sales_invoices.DocumentNumberGeneratorDelegate
+    fields: { type: "Sales Invoice" }
+    next: allocatePayments
+```
+
+`delegate` binds the step to a hand-written `JavaDelegate` in `custom/`. That delegate loads and saves the invoice through its **generated repository** (keeping validations, events and i18n) and defers the actual prefix + zero-padded formatting to a *separate, entity-agnostic* generator that lives in its own module, the `numbers` module (of the same repo):
+
+```java
+// custom/sales_invoices/DocumentNumberGeneratorDelegate.java  (in the invoices module)
+public class DocumentNumberGeneratorDelegate implements JavaDelegate {
+    public FixedValue type;                                     // injected from the step's `fields`
+    private final SalesInvoiceRepository repository = new SalesInvoiceRepository();
+
+    @Override public void execute(DelegateExecution execution) {
+        SalesInvoiceEntity invoice = repository.findById(((Number) execution.getVariable("Id")).intValue());
+        invoice.Number = new DocumentNumberGenerator().generateByType(type.getExpressionText());
+        repository.updateWithoutEvent(invoice);                 // system write: no "-updated" event
+    }
+}
+```
+
+The split is deliberate: the *number-formatting* logic (`DocumentNumberGenerator`) is entity-agnostic, so it lives once in the `numbers` module and is reused by every document module; the *delegate* that touches the invoice belongs in the invoice module, because it must go through that entity's generated repository. Custom code, written once, reused across the whole suite - and still never touched by regeneration.
+
+> 📸 *Screenshot: the web IDE editing the delegate - cross-module `import custom.numbers.DocumentNumberGenerator` resolved by the language server.*
+
+## Three things that will save you an hour
+
+Because client Java compiles as one in-process batch, a few rules matter in practice:
+
+- **Always use a named package.** A class in the default package cannot be imported or referenced from the generated repository - so the calculated action above declares `package custom.sales_invoices;`. The entity's `imports:` must import it by that fully-qualified name (or you give the action's fully-qualified class name directly).
+- **One bad file fails the whole batch.** All client `.java` across all projects compile together each cycle. A single file that does not compile takes down **every** project's Java endpoints with a 404 - not just the broken one. If Java routes vanish wholesale, look for one uncompilable source.
+- **Deleting from the workspace doesn't unpublish.** Removing a `.java` from your project leaves the published copy in the registry, where it is still compiled and served. Remove it from the registry too (or re-publish) or it lingers.
+
+## The point
+
+You did not fork the framework, override a generated file, or drop out of the platform. You declared a hook in the model and wrote one small class in `custom/`, with the same editing experience you would get in a desktop IDE. Regenerate the app as often as you like - your code stays put.
+
+That is the balance Dirigible strikes: **low-code where you can, real code where you must** - in one environment, in the browser. Clone [sample-intent-multi-model](https://github.com/dirigiblelabs/sample-intent-multi-model) and try swapping the implementation yourself.

--- a/docs/blogs/2026/07/04/documents-that-settle-themselves.md
+++ b/docs/blogs/2026/07/04/documents-that-settle-themselves.md
@@ -1,0 +1,152 @@
+---
+title: "Documents That Settle Themselves: Allocations, Cascading Forms and Cross-Module Reports"
+description: "How a Dirigible intent declares the behavior between business documents - payment allocation with automatic roll-ups, Depends-On forms that guide the user, and management reports that join data across modules."
+author: Nedelcho Delchev
+author_gh_user: delchev
+author_avatar: https://avatars.githubusercontent.com/u/6852373?v=4
+read_time: 8 min
+publish_date: July 4, 2026
+---
+
+The [first post](../01/intent-driven-sales-invoices.md) in this series built a Sales Invoices app from one intent file; the [second](../02/composing-a-business-suite.md) split the domain into independent modules that reuse each other's master data. This one is about what happens **between** the documents once the suite runs: a customer pays, and someone has to figure out *which invoices* that payment covers, keep every invoice's paid/outstanding amounts straight, and answer management's "who owes us what?"
+
+In most systems that is reconciliation code, UI event handlers and a reporting tool. On [Eclipse Dirigible](https://www.dirigible.io/) it is a few more blocks in the same intent file.
+
+## Many-to-many across modules
+
+An invoice can be settled by many payments, and a payment can span many invoices - a classic n:m, but the two sides live in **different** modules (the `sales-invoices` and `customer-payments` modules of [sample-intent-multi-model](https://github.com/dirigiblelabs/sample-intent-multi-model)). You model it as an explicit intermediate entity that carries the allocation amount:
+
+```yaml
+- name: SalesInvoiceCustomerPayment
+  fields:
+    - { name: id,     type: integer, primaryKey: true, generated: true }
+    - { name: amount, type: decimal, precision: 18, scale: 2, required: true }
+  relations:
+    - { name: SalesInvoice,    kind: manyToOne, to: SalesInvoice,    composition: true, required: true }
+    - { name: CustomerPayment, kind: manyToOne, to: CustomerPayment, model: customer-payments, required: true, show: [date, number] }
+```
+
+One side is a local composition (the invoice owns the allocation); the other is a cross-model reference to the payment.
+
+The **`show: [date, number]`** attribute surfaces the payment's booking date and bank transaction number as extra **read-only columns** in the invoice's allocations table. The FK lookup already fetches the referenced row to resolve its label, so these columns cost no extra request - and because no cross-app URL has to be built, `show` works even when the target lives in **another module**, as it does here.
+
+## Declarative settlement
+
+The link table is only half the story - who *creates* those allocations? On Eclipse Dirigible you declare it, you don't code it. The invoice module adds two blocks:
+
+```yaml
+# Paid = sum of the allocation amounts; Balance = Total - Paid; Status flips to PARTIAL / PAID.
+rollups:
+  - { name: invoicePaid, entity: SalesInvoiceCustomerPayment, via: SalesInvoice, field: paid, op: sum, of: amount,
+      capacity: total, balance: balance, status: Status, statusWhenFull: 7, statusWhenPartial: 6 }
+
+# Auto-allocation: spread a customer's payments across their open invoices (oldest first), matching
+# Customer + Currency, until spent - generated as client-Java glue under gen/events.
+settlements:
+  - { name: autoAllocate, junction: SalesInvoiceCustomerPayment, invoice: SalesInvoice, payment: CustomerPayment,
+      amount: amount, total: total, paid: paid, pot: amount, order: date,
+      match: [Customer, Currency], status: Status, payableStatuses: [3, 4, 6] }
+```
+
+The `rollups:` block keeps `Paid` / `Balance` / `Status` in lockstep with the allocations; the `settlements:` block generates the auto-allocation delegates. Both span **two modules** (invoices and payments) yet are declared entirely in the invoice's intent - no hand-written integration code.
+
+Auto-allocation is not a black box, either: the generated allocations panel on the invoice also offers a manual **Add** button and a per-row **Delete**, so a wrong allocation is corrected by removing the row and adding the right one. Manual changes go through the same generated repository as the automatic ones, so the `Paid` / `Balance` / `Status` roll-up recomputes either way.
+
+## Forms that react - Depends-On
+
+Settlement handles the machine's side; **Depends-On** handles the human's. A form control declares `dependsOn` on a sibling to-one relation (the trigger), and when the trigger's selection changes the control reacts - it re-filters its dropdown, or copies a value. Three shapes cover everything:
+
+```yaml
+# cascade - the City list narrows to the chosen Country's cities (filterBy)
+- { name: City, kind: manyToOne, to: City, model: countries,
+    dependsOn: { relation: Country, filterBy: Country } }
+
+# narrow-to-referenced - the UoM list narrows to the product's own base unit and auto-selects it
+- { name: UoM, kind: manyToOne, to: UoM, model: uoms,
+    dependsOn: { relation: Product, valueFrom: UoM } }
+
+# auto-populate - the line price is copied from the chosen product's default (still editable)
+- { name: price, type: decimal, precision: 18, scale: 2, required: true,
+    dependsOn: { relation: Product, valueFrom: price } }
+```
+
+A **relation** with `dependsOn` filters its options (`filterBy`; a single remaining option is auto-selected); a **field** with `dependsOn` copies a value (`valueFrom`). And crucially: **the trigger and the target may live in different modules** - above, `City`/`Country` belong to the `countries` module, `Product` to `products`, `UoM` to `uoms`, while the declaring entities sit in `customers` and `sales-invoices`.
+
+The payment-allocation dialog chains three of them into a guided flow: `Customer` is narrowed to the invoice's own customer, `CustomerPayment` is filtered to that customer's payments, and `amount` defaults to the chosen payment's amount - pick, pick, confirm:
+
+```yaml
+- name: SalesInvoiceCustomerPayment
+  fields:
+    - { name: amount, type: decimal, precision: 18, scale: 2, required: true,
+        dependsOn: { relation: CustomerPayment, valueFrom: amount } }
+  relations:
+    - { name: SalesInvoice,    kind: manyToOne, to: SalesInvoice, composition: true, required: true }
+    - { name: Customer,        kind: manyToOne, to: Customer, model: customers,
+        dependsOn: { relation: SalesInvoice, valueFrom: Customer } }
+    - { name: CustomerPayment, kind: manyToOne, to: CustomerPayment, model: customer-payments,
+        required: true, dependsOn: { relation: Customer, filterBy: Customer } }
+```
+
+That is the manual complement to the auto-settlement above: the machine allocates the obvious cases, and when a human steps in to correct one, the form itself steers them to the right payment with the right amount.
+
+> 📸 *Screenshot: the allocation dialog - customer pre-selected, payments filtered, amount pre-filled.*
+
+## Reports that join across modules
+
+Once the documents flow, management wants the numbers. The invoice module declares six reports in the same intent - a `reports:` block with a source entity, dimensions and aggregate measures:
+
+```yaml
+reports:
+  - name: InvoicesByCustomer
+    source: SalesInvoice
+    description: Invoice count, revenue, paid and outstanding balance per customer
+    dimensions: [Customer]
+    measures: ["count(*)", "sum(total)", "sum(paid)", "sum(balance)"]
+  - name: OverdueInvoices
+    source: SalesInvoice
+    dimensions: [number, date, due, Customer, total, balance]
+    filter: "due <= CURRENT_DATE AND balance > 0"
+  - name: SalesByProduct
+    source: SalesInvoiceItem
+    dimensions: [Product]
+    measures: ["sum(quantity)", "count(*)", "sum(total)"]
+```
+
+A dimension can be a plain field, a same-model relation (a status report shows the status name), or a **cross-model relation**: `Customer` and `Product` are owned by other modules, and the report joins the owning model's table to show the customer or product *name* instead of a raw foreign-key id. A `filter:` turns a report into a focused operational listing, like the overdue invoices above. Dimensions can also **bucket time** - `RevenueByMonth` and `MonthlyRevenue` group on `month(date)` for revenue, net and VAT per month.
+
+The generated app renders these as **Reports** pages in the sidebar, and every report table gets **typed per-column filters** - date ranges, number ranges, text contains - applied server-side, so pagination, counts and the CSV export all reflect what you filtered.
+
+**Some reports never open a page.** Add a `widget:` and the report becomes a KPI tile on the shared dashboard:
+
+```yaml
+  - name: OverdueInvoices
+    widget: { kind: count, label: Overdue Invoices, icon: alert-triangle }
+  - name: RevenueByMonth
+    dimensions: ["month(date)"]
+    measures: ["sum(total)"]
+    widget:
+      value: "sum(total)"
+      at: { "month(date)": now }     # pin the bucket to the current month
+      label: Revenue (this month)
+```
+
+The three widget kinds are `count` (the row count), `value` (a single aggregate cell - the `now` token in `at:` resolves at view time, so the tile always shows *this* month), and `list` (the first N rows). These business-meaningful KPIs replace the automatic per-entity record-count tiles the dashboard used to show.
+
+And a report can render as a **chart** instead of a table - `MonthlyRevenue` sets `chart: bar` and its page draws one bar per measure across the month buckets (`bar`, `line`, `pie`, `doughnut`, `polarArea` and `radar` are all available). A Table/Chart toggle keeps the filters, CSV export and print working on the same data.
+
+> 📸 *Screenshot: the InvoicesByCustomer report with per-column filters and dashboard tiles.*
+
+## Paper still happens - printing
+
+Invoices get sent, reports get handed out. Both print without writing a line of layout code:
+
+- **Documents** carry a **Print** button. Generation seeds a *print template* per document entity into the platform's CMS (`Templates/SalesInvoice/Print/en/standard.print`) - a small declarative layout (header, fields, items table, totals footer) that is merged with the live document and rendered **server-side to PDF**. The template is plain text in the CMS: download it from the Documents perspective, adjust the layout or wording (Cyrillic and other scripts render correctly), upload it back - customizations survive regeneration. Add a template per language (`Print/bg/`) and printing follows the user's **Region & Language** setting, offering the language choice when several exist.
+- **Reports** print too: the report pages gain a **Print** button that renders the **full filtered result set** (not just the visible page) into a clean print document - title, row count, timestamp, formatted numeric columns - and chart reports print a snapshot of the chart itself.
+
+Between the allocations keeping themselves consistent and the paperwork printing itself, what is left is the part only you can do: deciding what the business rules should be.
+
+## The payoff
+
+Allocation, roll-up, guided correction and reporting are the parts of a billing system that usually accumulate the most hand-written glue - and the most bugs. Here they are **four declarative blocks** in the intent that already owns the document: `relations` for the n:m, `rollups:` + `settlements:` for the money flow, `dependsOn` for the forms, `reports:` for the numbers. When the requirements change, you change the declaration and regenerate.
+
+The one piece of genuinely custom logic in the suite - the sequential invoice number - is hand-written Java, and that story is the [custom-Java post](../03/custom-java-in-the-web-ide.md). Everything else you have seen in this series came from intent files, and the full sample is [sample-intent-multi-model](https://github.com/dirigiblelabs/sample-intent-multi-model).


### PR DESCRIPTION
A four-part blog series on the intent layer, transferred from the codbex tech-blog and **re-branded to Eclipse Dirigible**:

1. **From Prompt to Running App** - single `app.intent` -> a full app ([sample-intent-model](https://github.com/dirigiblelabs/sample-intent-model))
2. **Composing a Business Suite** - multi-module, cross-model reuse, shared shell ([sample-intent-multi-model](https://github.com/dirigiblelabs/sample-intent-multi-model))
3. **When the Model Isn't Enough** - custom Java in the web IDE
4. **Documents That Settle Themselves** - allocations, Depends-On forms, cross-module reports

Sample references are limited to the two dirigiblelabs sample repos. The production pattern (each module its own repo + npm package) is kept as **guidance**; the sample keeps all modules in one repo, and no new repositories are implied.

Frontmatter converted to the site's blog format (author/gh/avatar/read_time/publish_date); body H1s removed (PostHeader renders the title); cross-post links relative. Verified: build clean, 0 codbex references, 0 em/en-dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)