### PR TITLE
docs(intent): add "Printing and documents" page

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -206,6 +206,7 @@ function helpSidebar() {
         { text: 'The AI assistant', link: '/help/intent/ai-assistant' },
         { text: 'Generators and generation', link: '/help/intent/generators' },
         { text: 'Declarative glue', link: '/help/intent/glue' },
+        { text: 'Printing and documents', link: '/help/intent/printing' },
       ],
     },
     {

--- a/docs/help/intent/generators.md
+++ b/docs/help/intent/generators.md
@@ -17,6 +17,7 @@ Generate runs every registered generator in `@Order`, writes the derived model f
 | `reports[]` | `<report>.report` (one per report) | 500 |
 | `permissions` | `<intent>.roles` | 600 |
 | `seeds[]` | `<seed>.csvim` + `<seed>.csv` (one pair per seed) | 700 |
+| document masters | `doc/Templates/<Entity>/Print/en/standard.print` | 800 |
 | triggers, resolvers, glue | `<intent>.glue` | (with the events template) |
 
 These cover every intent block defined today.
@@ -40,6 +41,7 @@ These cover every intent block defined today.
 - `ReportIntentGenerator` to `<report>.report` - the Dirigible `.report` shape with a materialised SQL `query` (joins from `relation.field` paths, `WHERE` from `filter`, default-role `security`). All physical identifiers double-quoted for Postgres.
 - `PermissionIntentGenerator` to `<intent>.roles` - deduped roles; no `.access` URL constraints (those belong to the downstream template).
 - `CsvimIntentGenerator` to `<seed>.csvim` + `<seed>.csv` - platform-default CSVIM settings; project-qualified CSV path.
+- `PrintIntentGenerator` to `doc/Templates/<Entity>/Print/en/standard.print` - a printable document template for each document (header-items) master. Unlike the others it writes under `doc/` (not the project root) and is **generate-once** (create-if-absent), so a hand-adapted invoice is never regenerated over. See [printing and documents](/help/intent/printing).
 
 See [the `.intent` file](/help/intent/intent-file) for the authoring shape each consumes, and [declarative glue](/help/intent/glue) for the `.glue` output.
 
@@ -52,6 +54,7 @@ This is the most important operational rule of the intent layer:
 - **Never write into `gen/`.** The model-to-code templates own that folder and wipe it wholesale on every regeneration; intent output placed there would be destroyed.
 - Generators **never reference template-engine output paths** - the intent layer is ignorant of which downstream template will consume its models, so it cannot couple to one template's choices.
 - Generation is **idempotent and diff-stable**: identical input produces byte-identical output; byte-identical content is not rewritten.
+- The **one exception** to root-only, always-rewrite is the print template ([printing and documents](/help/intent/printing)): it is written under `doc/` and **create-if-absent** (never regenerated over), because it is a hand-customized document rather than a derived model file. Everything under `doc/` is seeded into the CMS on publish.
 
 Output extensions are restricted to the model layer: `.edm` / `.model` / `.bpmn` / `.form` / `.report` / `.roles` / `.access` / `.glue` / `.dsm` / `.schema` / `.table` / `.view` / `.csvim` / `.csv`. Anything code-shaped (`*.ts`, `*.java`, `*.html`, `*.sql`, `*.css`) is the template engine's output and is never emitted by an intent generator. The one exception is the declarative-glue layer, which deliberately generates annotated client-Java - see [glue](/help/intent/glue).
 

--- a/docs/help/intent/index.md
+++ b/docs/help/intent/index.md
@@ -68,6 +68,7 @@ Model-layer files at the project root are owned by the regeneration pass. **Do n
 - [The AI assistant](/help/intent/ai-assistant) - Claude proposes a patch to the intent; you accept or refine.
 - [Generators and generation](/help/intent/generators) - what each generator produces, the regeneration contract, and `.settings`.
 - [Declarative glue](/help/intent/glue) - notifications, schedules, integrations, inbound webhooks, rollups and lifecycle triggers, generated as annotated client-Java.
+- [Printing and documents](/help/intent/printing) - the generated `.print` template, the `doc/` CMS-seed folder, the relation-aware print feeder, customization and multi-language.
 
 ## See also
 

--- a/docs/help/intent/printing.md
+++ b/docs/help/intent/printing.md
@@ -1,0 +1,124 @@
+---
+title: Printing and documents
+description: How an intent generates printable documents - the .print template, the doc/ CMS-seed folder, the relation-aware print feeder, customization and multi-language.
+---
+
+# Printing and documents
+
+A document (header-items) entity - one with an `*Item` composition child, like `SalesInvoice` + `SalesInvoiceItem` - gets a **printable document template** on Generate. The template is written in the document-template DSL (a small XML-like layout language), seeded into the CMS, and rendered to PDF on demand from the entity's own data.
+
+## The generated `.print` template
+
+`PrintIntentGenerator` emits one template per document master, at the exact path it must occupy in the CMS, under the project's `doc/` folder:
+
+```
+doc/Templates/<Entity>/Print/en/standard.print
+```
+
+The master is detected exactly like the document layout in the [entity generator](/help/intent/generators) - an entity that is the composition parent of a child named `*Item`. The generated template is a complete starting point: a humanized title, the document number subtitle, the header fields, an items table, and a totals footer.
+
+**It is generated once and never regenerated over.** Like the developer-owned `.settings` file, the template is written *create-if-absent*: a later Generate leaves an existing file untouched. This is deliberate - a printed business document is a formatted, audited artifact you adapt by hand, and a newly added model field must **not** silently appear on an already-designed invoice. Treat the generated file as a per-tenant starting layout to adapt, not a finished document.
+
+## The document-template DSL
+
+The template is a tree of layout tags. The ones you will use most:
+
+| Tag | Purpose |
+| --- | --- |
+| `<page width height padding>` | the page box |
+| `<header>` / `<footer>` | rendered once, top and bottom |
+| `<section>` / `<stack>` | a vertical block of content |
+| `<row>` | side-by-side columns, one per child `<stack width="...">` |
+| `<field label="...">` | a labelled value |
+| `<text style="title\|subtitle\|caption" align="...">` | free text |
+| `<table source="items">` + `<column width label>` | the line-items table |
+| `<total align="right">` | the emphasized document total |
+| `<line/>` | a horizontal rule |
+| `<if source="...">` | keep the children only when the value is present |
+
+Values are Mustache placeholders. A two-column header with the seller on the left and invoice meta on the right:
+
+```xml
+<header>
+  <row>
+    <stack width="55%">
+      <text style="title">{{document.Organization}}</text>
+      <text>{{document.Organization.Address}}</text>
+    </stack>
+    <stack width="45%">
+      <text align="right" style="title">INVOICE</text>
+      <field align="right" label="No">{{document.Number}}</field>
+      <field align="right" label="Date">{{document.Date}}</field>
+    </stack>
+  </row>
+  <line/>
+</header>
+
+<table source="items">
+  <column width="4*" label="Description">{{Name}}</column>
+  <column width="*" align="right" label="Qty">{{Quantity}}</column>
+  <column width="1.5*" align="right" label="Net">{{Net}}</column>
+</table>
+```
+
+Decimal values print in the money pattern (`### ### ### ##0.00`); an unresolved placeholder renders empty (a printout never shows raw braces). Wrap an optional field in `<if source="...">` so its label does not print when the value is blank.
+
+## The data contract - the print feeder
+
+The template binds against data supplied by a generated **print feeder** - a small `@Controller` (`gen/events/<Entity>PrintFeeder.java`) that loads the document and its related records through the generated repositories and returns a nested document-and-items payload. This is what lets a template reach related data, not just the document's own columns:
+
+```text
+{{document.<Property>}}            the document's own field
+{{document.<Relation>}}            a to-one relation's display label (e.g. the customer's name)
+{{document.<Relation>.<Field>}}    a field of the related record - e.g. document.Organization.Iban,
+                                   document.Customer.Address
+{{<Property>}}                     a line-item field (inside <table source="items">)
+```
+
+The feeder walks the document master's whole reachable to-one graph (two hops within the same model, one hop into a referenced module) and is regenerated with the application, so the generated Java is an exact, auditable record of everything a print receives. Because it loads through the repositories and is called by the browser as the signed-in user, it inherits the multilingual translation overlay (the document prints in the caller's language) and the caller's authorization and tenant - no server-side data fetching or credential forwarding. Date and timestamp fields are supplied as ISO strings; numbers are left raw so the template's money formatting applies.
+
+## The `doc/` folder and CMS seeding
+
+Everything under a project's **`doc/` folder** is seeded into the CMS on publish, mirroring the path it has under `doc/`:
+
+```
+<project>/doc/Templates/SalesInvoice/Print/en/standard.print
+        -> CMS  /Templates/SalesInvoice/Print/en/standard.print
+```
+
+The `CmsSeedSynchronizer` does this generically - it is not print-specific. Any file under `doc/` (print templates, images, other documents) is seeded as CMS content. Three rules:
+
+- **Create-if-absent, never overwrite** - the CMS copy is the business user's customization surface; a re-publish never clobbers it.
+- **Delete never touches the CMS** - removing the source file (or the project) removes only the tracking record; uploaded customizations survive.
+- **Per-tenant** - each tenant's publish seeds its own copy under its own CMS root.
+
+`doc/` is a raw CMS staging area - do not place model artefacts (`.csvim`, `.bpmn`, ...) there expecting their normal engines to run; under `doc/` they are treated as opaque content.
+
+## Customizing and multi-language
+
+Business users customize a document through the [Documents perspective](/help/ide/perspectives/documents): download the seeded `standard.print`, edit it, and upload it back - the upload is the version that prints, and it is never overwritten by a re-publish.
+
+Only English (`en`) is generated. To add a language, add another file under a sibling language folder:
+
+```
+doc/Templates/SalesInvoice/Print/en/standard.print
+doc/Templates/SalesInvoice/Print/bg/standard.print
+```
+
+When several languages exist, the Print button asks which to use; otherwise it prints the only one. The default follows the user's Region &amp; Language setting.
+
+## Printing at runtime
+
+In a generated document view, the **Print** button (available while editing a record) calls the feeder for the current record, then posts the payload to the print service, which resolves the template from the CMS, binds the data, and returns a PDF:
+
+- `GET /services/print/{entity}/languages` - the languages a document has templates for.
+- `POST /services/print/{entity}?lang=en` with `{ "document": { ... }, "items": [ ... ] }` - returns `application/pdf`.
+
+Rendering goes through the document parser, the data binder, and an XSL-FO / Apache FOP transform to PDF.
+
+## See also
+
+- [Generators and generation](/help/intent/generators)
+- [The `.intent` file](/help/intent/intent-file)
+- [The Documents perspective](/help/ide/perspectives/documents)
+- [The synchronizer model](/help/concepts/synchronizer-model)


### PR DESCRIPTION
Documents the print/document feature of the intent layer (platform PR eclipse-dirigible/dirigible#6184), which had no docs.

New page **`/help/intent/printing`** covering:
- the generated `.print` template (one per document master), written under `doc/Templates/<Entity>/Print/en/standard.print` and **generate-once** (create-if-absent);
- the document-template DSL basics — layout tags + Mustache placeholders;
- the relation-aware **print feeder** data contract — `{{document.<Relation>.<Field>}}` resolves related-record fields, auditable, i18n/auth/tenant-correct;
- the generic **`doc/` → CMS seeding** — anything under `doc/**` is mirrored into the tenant CMS, create-if-absent, delete-safe, per-tenant;
- customization via the Documents perspective + multi-language folders;
- the runtime Print flow and `/services/print` endpoints.

Also registers the page in the Intent sidebar (`config.mts`) and overview (`index.md`), and adds the print generator row + the create-if-absent exception note to `generators.md`.

`vitepress build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)