### PR TITLE
ci: retry GitHub Pages deploy on transient sync failure

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,11 +39,16 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url }}
     needs: build
     runs-on: ubuntu-latest
     name: Deploy
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
+        uses: actions/deploy-pages@v4
+        continue-on-error: true
+      - name: Deploy to GitHub Pages (retry)
+        id: deployment_retry
+        if: steps.deployment.outcome == 'failure'
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem

The **Deploy VitePress site to Pages** job intermittently fails with:

```
##[error]Deployment failed, try again later.
```

during `actions/deploy-pages` at the `syncing_files` step. The `build` job succeeds and uploads the artifact fine — this is a GitHub Pages backend hiccup, not a content or build problem (verified: no file over the 100 MB limit, site well under the size caps, failing changes were trivial markdown/small images). Two runs failed this way; both were fixed by a manual re-run.

## Fix

Retry the deploy once, natively (no third-party action):

- First `deploy-pages` attempt is `continue-on-error: true`, so a transient sync failure no longer reds the job.
- A second `deploy-pages` step runs only `if: steps.deployment.outcome == 'failure'`.
- `environment.url` falls back to the retry step's `page_url` so the deployment URL is correct whichever attempt wins.

If **both** attempts fail it's a genuine incident and the job still goes red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)