### PR TITLE
docs(intent): intent DSL reference + SDK ValidationException / checks-400

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -201,6 +201,7 @@ function helpSidebar() {
       items: [
         { text: 'Overview', link: '/help/intent/' },
         { text: 'The .intent file', link: '/help/intent/intent-file' },
+        { text: 'DSL reference', link: '/help/intent/dsl-reference' },
         { text: 'Multi-model applications', link: '/help/intent/multi-model' },
         { text: 'The Intent Editor', link: '/help/intent/editor' },
         { text: 'The AI assistant', link: '/help/intent/ai-assistant' },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -916,6 +916,7 @@ function sdkSidebar() {
           items: [
             { text: 'Database', link: '/sdk/db/database' },
             { text: 'Store', link: '/sdk/db/store' },
+            { text: 'ValidationException', link: '/sdk/db/validation-exception' },
             { text: 'Decorators', link: '/sdk/db/decorators' },
           ],
         },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -200,7 +200,7 @@ function helpSidebar() {
       collapsed: true,
       items: [
         { text: 'Overview', link: '/help/intent/' },
-        { text: 'The .intent file', link: '/help/intent/intent-file' },
+        { text: 'The Intent file', link: '/help/intent/intent-file' },
         { text: 'DSL reference', link: '/help/intent/dsl-reference' },
         { text: 'Multi-model applications', link: '/help/intent/multi-model' },
         { text: 'The Intent Editor', link: '/help/intent/editor' },

--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -13,32 +13,32 @@ complete worked example.
 | Construct | What it gives you |
 |---|---|
 | [`entities`](#entities) | tables + CRUD UI + generated Java repository/REST |
-| [field / relation attributes](#field--relation-attributes) | uniqueness, layout, read-only, dropdown filtering, cascades |
-| [`function`](#function---presentation-role) | explicit presentation role (Document, Setting, ...) |
-| [`checks`](#checks---declarative-validations) | cross-field / cross-line validations |
-| [`immutableIn`](#immutablein---status-keyed-immutability) | 409 on user writes in a given status |
-| [`hierarchy` / `leafOnly`](#hierarchy--leafonly---tree-entities) | tree entities, leaf-only references |
-| [`multilingual` / `languages`](#multilingual---translated-master-data) | `_LANG` tables + read-time translation overlay |
-| [calculated fields](#calculated-fields--actions) | server+UI-evaluated expressions, date functions, Java call-outs |
-| [`view`](#view---calendar-range-slots) | calendar / range / slot-booking pages |
-| [`uses`](#uses---cross-model-references) | reuse entities owned by another intent model |
-| [`processes`](#processes---workflows) | BPM workflows with user tasks, decisions, delegates |
-| [`forms`](#forms---task-ui) | task data-entry pages |
-| [`actions`](#actions---custom-buttons) | developer-defined buttons opening custom pages |
-| [`generates`](#generates---create-from) | one-click document-from-document cloning |
-| [`postings`](#postings---source-document-to-ledger) | declarative source-document to balanced-document posting |
-| [`expansions`](#expansions---child-rows-from-a-date-span) | generated child rows per day/week/month |
-| [`rollups`](#rollups---denormalised-parent-totals) | counts, sums, balance + status maintenance, transitive chains |
-| [`settlements`](#settlements---payment-allocation) | auto-allocation of payments across open invoices |
-| [`reports`](#reports---read-only-aggregations) | aggregations, charts, dashboard KPI tiles, balance reports |
-| [`widgets`](#widgets---custom-dashboard-tiles) | custom KPI / embedded-page dashboard tiles |
-| [`seeds`](#seeds---initial-data) | initial data, CSV-backed sets, translations |
-| [`notifications`](#notifications---email-on-change) | email on create/update/delete |
-| [`schedules`](#schedules---cron) | cron: notify or generate records per matching row |
-| [`integrations`](#integrations---outbound-http) | outbound HTTP on a data change |
-| [`inbound`](#inbound---webhooks) | webhook that creates records |
-| [`permissions`](#permissions---roles) | roles |
-| [Planned](#planned---recognised-but-not-yet-implemented) | recognised, not yet implemented |
+| [field / relation attributes](#field-relation-attributes) | uniqueness, layout, read-only, dropdown filtering, cascades |
+| [`function`](#function-presentation-role) | explicit presentation role (Document, Setting, ...) |
+| [`checks`](#checks-declarative-validations) | cross-field / cross-line validations |
+| [`immutableIn`](#immutablein-status-keyed-immutability) | 409 on user writes in a given status |
+| [`hierarchy` / `leafOnly`](#hierarchy-leafonly-tree-entities) | tree entities, leaf-only references |
+| [`multilingual` / `languages`](#multilingual-translated-master-data) | `_LANG` tables + read-time translation overlay |
+| [calculated fields](#calculated-fields-actions) | server+UI-evaluated expressions, date functions, Java call-outs |
+| [`view`](#view-calendar-range-slots) | calendar / range / slot-booking pages |
+| [`uses`](#uses-cross-model-references) | reuse entities owned by another intent model |
+| [`processes`](#processes-workflows) | BPM workflows with user tasks, decisions, delegates |
+| [`forms`](#forms-task-ui) | task data-entry pages |
+| [`actions`](#actions-custom-buttons) | developer-defined buttons opening custom pages |
+| [`generates`](#generates-create-from) | one-click document-from-document cloning |
+| [`postings`](#postings-source-document-to-ledger) | declarative source-document to balanced-document posting |
+| [`expansions`](#expansions-child-rows-from-a-date-span) | generated child rows per day/week/month |
+| [`rollups`](#rollups-denormalised-parent-totals) | counts, sums, balance + status maintenance, transitive chains |
+| [`settlements`](#settlements-payment-allocation) | auto-allocation of payments across open invoices |
+| [`reports`](#reports-read-only-aggregations) | aggregations, charts, dashboard KPI tiles, balance reports |
+| [`widgets`](#widgets-custom-dashboard-tiles) | custom KPI / embedded-page dashboard tiles |
+| [`seeds`](#seeds-initial-data) | initial data, CSV-backed sets, translations |
+| [`notifications`](#notifications-email-on-change) | email on create/update/delete |
+| [`schedules`](#schedules-cron) | cron: notify or generate records per matching row |
+| [`integrations`](#integrations-outbound-http) | outbound HTTP on a data change |
+| [`inbound`](#inbound-webhooks) | webhook that creates records |
+| [`permissions`](#permissions-roles) | roles |
+| [Planned](#planned-recognised-but-not-yet-implemented) | recognised, not yet implemented |
 
 ## entities
 
@@ -152,7 +152,7 @@ entities:
     multilingual: true         # sibling <TABLE>_LANG table; reads overlay per Accept-Language
 ```
 
-Translations are seeds with a `language:` code (see [seeds](#seeds---initial-data)). The
+Translations are seeds with a `language:` code (see [seeds](#seeds-initial-data)). The
 platform's supported language set is `DIRIGIBLE_APPLICATION_LANGUAGES`.
 
 ## Calculated fields / actions

--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -15,17 +15,21 @@ complete worked example.
 | [`entities`](#entities) | tables + CRUD UI + generated Java repository/REST |
 | [field / relation attributes](#field-relation-attributes) | uniqueness, layout, read-only, dropdown filtering, cascades |
 | [`function`](#function-presentation-role) | explicit presentation role (Document, Setting, ...) |
+| [`label`](#label-stored-display-name) | a stored, read-only display name for lookups and dropdowns |
 | [`checks`](#checks-declarative-validations) | cross-field / cross-line validations |
 | [`immutableWhen` / `immutable`](#immutablewhen-immutable-user-write-immutability) | 409 on user writes in a status / append-only snapshots |
 | [`hierarchy` / `leafOnly`](#hierarchy-leafonly-tree-entities) | tree entities, leaf-only references |
 | [`multilingual` / `languages`](#multilingual-translated-master-data) | `_LANG` tables + read-time translation overlay |
+| [`personal` / `partner`](#personal-and-partner-surfaces) | per-user (My) and per-partner record scoping |
 | [calculated fields](#calculated-fields-actions) | server+UI-evaluated expressions, date functions, Java call-outs |
 | [`view`](#view-calendar-range-slots) | calendar / range / slot-booking pages |
+| [`documentItemsLayout: chat`](#documentitemslayout-chat-conversation-threads) | render document items as a conversation thread |
 | [`uses`](#uses-cross-model-references) | reuse entities owned by another intent model |
 | [`processes`](#processes-workflows) | BPM workflows with user tasks, decisions, delegates |
 | [`forms`](#forms-task-ui) | task data-entry pages |
 | [`actions`](#actions-custom-buttons) | developer-defined buttons opening custom pages |
 | [`generates`](#generates-create-from) | one-click document-from-document cloning |
+| [`transitions`](#transitions-guarded-status-flips) | guarded on-demand status flips (void / cancel / reopen) |
 | [`postings`](#postings-source-document-to-ledger) | declarative source-document to balanced-document posting |
 | [`expansions`](#expansions-child-rows-from-a-date-span) | generated child rows per day/week/month |
 | [`rollups`](#rollups-denormalised-parent-totals) | counts, sums, balance + status maintenance, transitive chains |
@@ -102,6 +106,21 @@ Optional and authoritative when set; inferred from structure otherwise.
 Values: `Document`, `DocumentItem`, `Master`, `Detail`, `List`, `Setting` (entity);
 `DocumentTitle` (field); `EntityStatus` (relation).
 
+## label - stored display name
+
+A stored, read-only `Name` recomputed on every write, so lookups and dropdowns show a meaningful
+label instead of a raw id.
+
+```yaml
+- name: SalesInvoice
+  label: "{Number} - {Date|yyyy MMMM} - {Customer.name}"
+```
+
+Tokens are own fields or **one-hop** to-one relation properties (`{Customer.name}`); `|format` is a
+date pattern for temporal values. Deeper paths are rejected - compose by referencing the related
+entity's own label (`{Parent.Name}`). Not allowed next to an authored `name` field, and a token must
+never reference a `sensitive` field.
+
 ## checks - declarative validations
 
 Row-level `exactlyOne` on every user write; document-level `itemsMin` / `itemsSumEqual` gated on
@@ -161,6 +180,34 @@ entities:
 Translations are seeds with a `language:` code (see [seeds](#seeds-initial-data)). The
 platform's supported language set is `DIRIGIBLE_APPLICATION_LANGUAGES`.
 
+## personal and partner surfaces
+
+Scope an entity's records to the logged-in user (the **My** shell) or to an external business
+partner (the **Partner** shell), on top of the regular controller which is unaffected.
+
+```yaml
+entities:
+  - name: Employee
+    identity: email                       # the string field matched against the login username
+  - name: Timesheet
+    relations:
+      - { name: Employee, kind: manyToOne, to: Employee, personal: true }   # the record owner
+    fields:
+      - { name: rate, type: decimal, sensitive: true }   # hidden + ignored on the personal surface
+```
+
+- `identity: <field>` on the owner entity names the string field (conventionally a unique e-mail)
+  matched against the login username.
+- `personal: true` on a record-owning to-one (at most one per entity; target must declare `identity`;
+  never on a composition parent - children inherit the scope) generates an additional
+  `<Entity>MyController` served on the **My** shell (`/services/web/my/`): reads filtered to the
+  caller's record, the owner FK forced server-side on writes, foreign records 404.
+- `partner: true` is the exact mirror for EXTERNAL parties (customers, suppliers) on the **Partner**
+  shell (`/services/web/partner/`), gated by the IdP roles (`Customer` / `Supplier` / `Partner`). An
+  entity can carry both `personal:` and `partner:` at once.
+- `sensitive: true` on a field (not the PK, identity, or owner FK) strips it from personal and partner
+  responses and ignores it on their writes - use it for rates and amounts the person must not see.
+
 ## Calculated fields / actions
 
 Neutral arithmetic expressions run on the server and preview live in the UI; date functions
@@ -187,6 +234,31 @@ out.
   view: slots                                      # slot-picker booking page
   slots: { start: startTime }
 ```
+
+## documentItemsLayout: chat - conversation threads
+
+On a document (header-items) master, render the line-items child as a chat thread (message bubbles
+plus a composer) instead of the editable table - the shape for support cases, tickets and comment
+threads. The header, status pill, process tasks and print stay as in a normal document.
+
+```yaml
+- name: Case
+  function: Document
+  documentItemsLayout: chat
+  relations:
+    - { name: Status, kind: manyToOne, to: CaseStatus, function: EntityStatus, init: 1 }
+- name: CaseMessage
+  function: DocumentItem
+  audit: true                                      # bubble author/time come from CreatedBy/CreatedAt
+  fields:
+    - { name: body,     type: text,    messageBody: true }      # the bubble text (exactly one)
+    - { name: internal, type: boolean, messageInternal: true }  # a memo, hidden from the partner surface
+  relations:
+    - { name: Case, kind: manyToOne, to: Case, composition: true, required: true }
+```
+
+The items child must declare `audit: true` and exactly one `messageBody: true` field; own-vs-other
+alignment keys on the audit author against the logged-in user.
 
 ## uses - cross-model references
 
@@ -263,6 +335,24 @@ generates:
 
 Adds a button on the source view; the clone saves through the target's repository so numbering,
 status init and calculated fields fire.
+
+## transitions - guarded status flips
+
+A per-record button that flips an entity's `function: EntityStatus` relation on demand - void,
+cancel, close, reopen - guarded by the allowed source statuses and an optional condition. A flip from
+any other status (or a failing guard) returns **HTTP 409**; a successful flip publishes the
+`-transitioned` event (which `postings` and integrations can consume).
+
+```yaml
+transitions:
+  - name: VoidInvoice
+    forEntity: Invoice            # must declare a function: EntityStatus relation
+    from: [3, 4]                  # allowed source status seed ids
+    setStatus: 8                  # the target status seed id (not one of `from`)
+    when: "Paid == 0"             # optional guard: <Field> ==|!= <number>
+    label: Void
+    icon: ban
+```
 
 ## postings - source-document to ledger
 
@@ -459,10 +549,10 @@ Reports, Settings including Region & Language).
 - **Declarative glue actions beyond the current set**: publish/consume message,
   `generateDocument` (PDF), `assign`, process-step events, inbound message/file events. Today's
   implemented glue: triggers, decision/form resolvers, notifications, schedules, integrations,
-  inbound webhooks, rollups, settlements, expansions, generates, postings.
+  inbound webhooks, rollups, settlements, expansions, generates, transitions, postings.
 - **Cross-model schedule source** - a schedule's `entity` must be local (the generate target may
   be cross-model).
 - ~~`generates` completion hook~~ - landed: `sourceStatus` flips the source's status after the
   target is created.
-- **Embedded calendar panel for a dependent composition child** inside its master page -
-  calendar views require a primary entity today.
+- ~~Embedded calendar panel for a dependent composition child~~ - landed: a composition child with a
+  date field renders an embedded calendar panel inside its master page.

--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -449,9 +449,9 @@ Reports, Settings including Region & Language).
 
 ## Planned - recognised but not yet implemented
 
-- **`function: Calendar`** - reserved as an entity presentation role; rejected with a clear "not
-  yet available" message (the `view: calendar|range|slots` pages above are the current calendar
-  surface). Likewise other reserved `function` values for upcoming templates.
+- Other reserved `function` values for upcoming templates are recognised but rejected with a
+  clear "not yet available" message. (`function: Calendar` is now first-class - the role alias
+  for `view: calendar`.)
 - **`manyToMany`** - parsed but never materialized; the supported shape is the explicit
   intermediate entity.
 - **Declarative glue actions beyond the current set**: publish/consume message,
@@ -460,7 +460,7 @@ Reports, Settings including Region & Language).
   inbound webhooks, rollups, settlements, expansions, generates, postings.
 - **Cross-model schedule source** - a schedule's `entity` must be local (the generate target may
   be cross-model).
-- **`generates` completion hook** - flipping the source record's status after creating the
-  target is not yet expressible.
+- ~~`generates` completion hook~~ - landed: `sourceStatus` flips the source's status after the
+  target is created.
 - **Embedded calendar panel for a dependent composition child** inside its master page -
   calendar views require a primary entity today.

--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -16,7 +16,7 @@ complete worked example.
 | [field / relation attributes](#field-relation-attributes) | uniqueness, layout, read-only, dropdown filtering, cascades |
 | [`function`](#function-presentation-role) | explicit presentation role (Document, Setting, ...) |
 | [`checks`](#checks-declarative-validations) | cross-field / cross-line validations |
-| [`immutableIn`](#immutablein-status-keyed-immutability) | 409 on user writes in a given status |
+| [`immutableWhen` / `immutable`](#immutablewhen-immutable-user-write-immutability) | 409 on user writes in a status / append-only snapshots |
 | [`hierarchy` / `leafOnly`](#hierarchy-leafonly-tree-entities) | tree entities, leaf-only references |
 | [`multilingual` / `languages`](#multilingual-translated-master-data) | `_LANG` tables + read-time translation overlay |
 | [calculated fields](#calculated-fields-actions) | server+UI-evaluated expressions, date functions, Java call-outs |
@@ -118,15 +118,19 @@ authored message.
     - { kind: exactlyOne, fields: [debit, credit], message: "Exactly one of debit/credit" }
 ```
 
-## immutableIn - status-keyed immutability
+## immutableWhen / immutable - user-write immutability
 
 ```yaml
 - name: JournalEntry
-  immutableIn: [2]     # while Status holds seed id 2 (POSTED), REST update/delete return 409
+  immutableWhen: "Status == 2"   # while POSTED, REST update/delete return 409 (join terms with ||)
+- name: InvoiceSnapshot
+  immutable: true                # append-only: e.g. the frozen copy stored when an invoice is SENT
 ```
 
-Requires a `function: EntityStatus` relation. Workflow/system writes through the repository stay
-possible - corrections to an immutable record are flow-generated reversals, never edits.
+`immutableWhen` requires a `function: EntityStatus` relation; `immutable: true` needs none and is
+mutually exclusive with it. Workflow/system writes through the repository stay possible -
+corrections to an immutable record are flow-generated reversals, never edits. (`immutableIn:` is
+the pre-rename spelling, rejected with a migration message.)
 
 ## hierarchy / leafOnly - tree entities
 

--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -1,0 +1,462 @@
+---
+title: DSL reference
+description: Quick index of every supported intent construct - one line and one snippet each - plus the recognised-but-not-yet-implemented list.
+---
+
+# DSL reference
+
+The quick lookup surface for the intent DSL: one line and one minimal snippet per construct. The
+in-product assistant guide (shipped with the engine) remains the authoritative reference for
+rules, edge cases and validation messages; [The `.intent` file](/help/intent/intent-file) walks a
+complete worked example.
+
+| Construct | What it gives you |
+|---|---|
+| [`entities`](#entities) | tables + CRUD UI + generated Java repository/REST |
+| [field / relation attributes](#field--relation-attributes) | uniqueness, layout, read-only, dropdown filtering, cascades |
+| [`function`](#function---presentation-role) | explicit presentation role (Document, Setting, ...) |
+| [`checks`](#checks---declarative-validations) | cross-field / cross-line validations |
+| [`immutableIn`](#immutablein---status-keyed-immutability) | 409 on user writes in a given status |
+| [`hierarchy` / `leafOnly`](#hierarchy--leafonly---tree-entities) | tree entities, leaf-only references |
+| [`multilingual` / `languages`](#multilingual---translated-master-data) | `_LANG` tables + read-time translation overlay |
+| [calculated fields](#calculated-fields--actions) | server+UI-evaluated expressions, date functions, Java call-outs |
+| [`view`](#view---calendar-range-slots) | calendar / range / slot-booking pages |
+| [`uses`](#uses---cross-model-references) | reuse entities owned by another intent model |
+| [`processes`](#processes---workflows) | BPM workflows with user tasks, decisions, delegates |
+| [`forms`](#forms---task-ui) | task data-entry pages |
+| [`actions`](#actions---custom-buttons) | developer-defined buttons opening custom pages |
+| [`generates`](#generates---create-from) | one-click document-from-document cloning |
+| [`postings`](#postings---source-document-to-ledger) | declarative source-document to balanced-document posting |
+| [`expansions`](#expansions---child-rows-from-a-date-span) | generated child rows per day/week/month |
+| [`rollups`](#rollups---denormalised-parent-totals) | counts, sums, balance + status maintenance, transitive chains |
+| [`settlements`](#settlements---payment-allocation) | auto-allocation of payments across open invoices |
+| [`reports`](#reports---read-only-aggregations) | aggregations, charts, dashboard KPI tiles, balance reports |
+| [`widgets`](#widgets---custom-dashboard-tiles) | custom KPI / embedded-page dashboard tiles |
+| [`seeds`](#seeds---initial-data) | initial data, CSV-backed sets, translations |
+| [`notifications`](#notifications---email-on-change) | email on create/update/delete |
+| [`schedules`](#schedules---cron) | cron: notify or generate records per matching row |
+| [`integrations`](#integrations---outbound-http) | outbound HTTP on a data change |
+| [`inbound`](#inbound---webhooks) | webhook that creates records |
+| [`permissions`](#permissions---roles) | roles |
+| [Planned](#planned---recognised-but-not-yet-implemented) | recognised, not yet implemented |
+
+## entities
+
+The data model - every entity becomes a table, a generated Java repository + REST controller, and
+a UI page. Integer primary keys only; composition is opt-in.
+
+```yaml
+entities:
+  - name: Member
+    icon: user
+    audit: true                # adds CreatedAt/CreatedBy/UpdatedAt/UpdatedBy
+    group: master-data         # nav group in the shared application shell
+    fields:
+      - { name: id,   type: integer, primaryKey: true, generated: true }
+      - { name: name, type: string,  required: true, length: 200 }
+    relations:
+      - { name: loans, kind: oneToMany, to: Loan }
+  - name: Loan
+    fields:
+      - { name: id,    type: integer, primaryKey: true, generated: true }
+      - { name: dueOn, type: date }
+    relations:
+      - { name: member, kind: manyToOne, to: Member, composition: true }  # detail of Member
+```
+
+## Field / relation attributes
+
+```yaml
+- { name: code,  type: string, unique: true, length: 30 }              # UNIQUE constraint
+- { name: uuid,  type: uuid, major: false }                            # off the list table
+- { name: total, type: decimal, precision: 18, scale: 2, readOnly: true }
+- { name: number, type: string, function: DocumentTitle }              # the document title/number
+- { name: Currency, kind: manyToOne, to: Currency, size: 4 }           # form width (12-col grid)
+- { name: Payment, kind: manyToOne, to: Payment, show: [date, number] }  # extra read-only lookup columns
+- { name: Status, kind: manyToOne, to: OrderStatus, function: EntityStatus, init: 1 }  # managed badge, seeded default
+# Depends-On - cascade, narrow-to-referenced, auto-populate:
+- { name: City,  kind: manyToOne, to: City, dependsOn: { relation: Country, filterBy: Country } }
+- { name: UoM,   kind: manyToOne, to: UoM,  dependsOn: { relation: Product, valueFrom: UoM } }
+- { name: price, type: decimal,             dependsOn: { relation: Product, valueFrom: price } }
+# Static option filter - e.g. only stock-tracked products:
+- { name: Product, kind: manyToOne, to: Product, where: { Type: 1 } }
+```
+
+Entity-level extras: `order: [Id, Product, Quantity, ...]` sequences form controls and list
+columns; `duplicable: true` adds a Duplicate button on a document (clones header + items through
+the normal create path); `imports: |` injects Java import lines into the generated repository
+(pairs with calculated actions); `aggregate: true` on a document master's numeric field keeps it
+equal to the sum of the items' same-named field (the totals footer).
+
+## function - presentation role
+
+Optional and authoritative when set; inferred from structure otherwise.
+
+```yaml
+- name: ProjectTimesheet
+  function: Document           # header + line items + status pill + totals
+- name: EmployeeTimesheet
+  function: DocumentItem       # its line items (no "*Item" naming needed)
+```
+
+Values: `Document`, `DocumentItem`, `Master`, `Detail`, `List`, `Setting` (entity);
+`DocumentTitle` (field); `EntityStatus` (relation).
+
+## checks - declarative validations
+
+Row-level `exactlyOne` on every user write; document-level `itemsMin` / `itemsSumEqual` gated on
+a status transition - drafting stays unconstrained, and a failing transition aborts with the
+authored message.
+
+```yaml
+- name: JournalEntry
+  checks:
+    - { kind: itemsMin,      count: 1, status: 2, message: "An entry needs at least one line" }
+    - { kind: itemsSumEqual, over: [debit, credit], status: 2, message: "Debits must equal credits" }
+- name: JournalEntryItem
+  checks:
+    - { kind: exactlyOne, fields: [debit, credit], message: "Exactly one of debit/credit" }
+```
+
+## immutableIn - status-keyed immutability
+
+```yaml
+- name: JournalEntry
+  immutableIn: [2]     # while Status holds seed id 2 (POSTED), REST update/delete return 409
+```
+
+Requires a `function: EntityStatus` relation. Workflow/system writes through the repository stay
+possible - corrections to an immutable record are flow-generated reversals, never edits.
+
+## hierarchy / leafOnly - tree entities
+
+```yaml
+- name: Account
+  hierarchy: Parent                                        # the tree edge (self-relation)
+  relations:
+    - { name: Parent, kind: manyToOne, to: Account }
+# elsewhere - only leaf accounts are referenceable (server-enforced):
+- { name: Account, kind: manyToOne, to: Account, model: accounts, leafOnly: true }
+```
+
+The list renders as an expandable tree; the server rejects cycles and leaf-only references to a
+node with children.
+
+## multilingual - translated master data
+
+```yaml
+languages: [en, bg]            # the languages this module PROVIDES translations for
+entities:
+  - name: UoM
+    kind: setting
+    multilingual: true         # sibling <TABLE>_LANG table; reads overlay per Accept-Language
+```
+
+Translations are seeds with a `language:` code (see [seeds](#seeds---initial-data)). The
+platform's supported language set is `DIRIGIBLE_APPLICATION_LANGUAGES`.
+
+## Calculated fields / actions
+
+Neutral arithmetic expressions run on the server and preview live in the UI; date functions
+included. For logic beyond an expression, a hand-written `CalculatedField` component is called
+out.
+
+```yaml
+- { name: net, type: decimal, calculatedOnCreate: "Quantity * Price", calculatedOnUpdate: "Quantity * Price" }
+- { name: days, type: decimal, readOnly: true,
+    calculatedOnCreate: "businessDaysBetween(FromDate, ToDate)" }     # also daysBetween, monthsBetween
+- { name: number, type: string, calculatedActionOnCreate: SalesInvoiceNumberAction }  # + entity imports:
+```
+
+## view - calendar, range, slots
+
+```yaml
+- name: EmployeeDayAllocation
+  view: calendar                                   # month/week calendar of records
+  calendar: { start: day, title: note }            # start (date/timestamp) required; end/title/color optional
+- name: VacationRequest
+  view: range                                      # from-to bars (leave calendar)
+  calendar: { start: fromDate, end: toDate }
+- name: Appointment
+  view: slots                                      # slot-picker booking page
+  slots: { start: startTime }
+```
+
+## uses - cross-model references
+
+Entities owned by another intent model are referenced read-only (a projection + FK + dropdown -
+no local table/DAO). Generate leaf-first so the owner's model exists. See
+[Multi-model applications](/help/intent/multi-model).
+
+```yaml
+uses:
+  - { model: countries }
+entities:
+  - name: Supplier
+    relations:
+      - { name: Country, kind: manyToOne, to: Country, model: countries }
+```
+
+Many-to-many is an explicit intermediate entity (composition to one side + `manyToOne` to the
+other, plus bridge fields); `manyToMany` is parsed but never materialized.
+
+## processes - workflows
+
+```yaml
+processes:
+  - name: OrderApproval
+    trigger: { onCreate: Order }
+    steps:
+      - { name: review,   kind: userTask, args: { assignee: manager, form: ApproveOrder } }
+      - { name: decide,   kind: decision, args: { if: "action == 'approve'", then: activate, else: cancel } }
+      - { name: activate, kind: serviceTask, args: { setRelationField: Status, value: 2, next: end } }
+      - name: number
+        kind: serviceTask
+        args: { delegate: custom.orders.NumberDelegate, fields: { type: "Order" }, next: end }
+      - { name: cancel,   kind: serviceTask, args: { setRelationField: Status, value: 3, next: end } }
+      - { name: end,      kind: end }
+```
+
+Service-task shapes: `setField` / `setRelationField` (generated handlers), `delegate` (a reusable
+hand-written client `JavaDelegate` with injected `fields`). Decisions may test `relation.field`
+paths (`customer.creditLimit > 10000`) - resolvers are generated. Tasks surface in the Inbox and
+inline on the record's page.
+
+## forms - task UI
+
+```yaml
+forms:
+  - name: ApproveOrder
+    forEntity: Order
+    fields: [orderDate, total, customer.name]     # fields or one-hop relation.field
+    actions: [approve, reject]                    # complete the BPM task
+```
+
+## actions - custom buttons
+
+```yaml
+actions:
+  - name: OpenPortal
+    forEntity: Order
+    scope: entity            # per-record; 'page' = whole-view toolbar
+    page: /services/web/myapp/custom/portal.html
+```
+
+## generates - create-from
+
+```yaml
+generates:
+  - name: invoice-from-timesheet
+    from: ProjectTimesheet
+    to: SalesInvoice
+    uses: sales                       # model alias when the target is cross-model
+    map: { Customer: Customer }
+    defaults: { InvoiceDate: now }
+    items: { from: ProjectTimesheetItem, to: SalesInvoiceItem, map: { Description: Description } }
+```
+
+Adds a button on the source view; the clone saves through the target's repository so numbering,
+status init and calculated fields fire.
+
+## postings - source-document to ledger
+
+When a (usually cross-model) source document reaches a status, create one local document with
+computed multi-line content. Idempotent via the back-reference; a missing rule or account skips
+(the unposted worklist), never throws.
+
+```yaml
+postings:
+  - name: salesInvoicePosting
+    event: { onTransition: SalesInvoice, model: sales-invoices, when: "Status == 3" }
+    creates: JournalEntry
+    backReference: SalesInvoice
+    map: { entryDate: date, reason: "Sales invoice {number}" }
+    rule: { entity: PostingRule, match: { documentType: "Sales Invoice" } }
+    items:
+      - { Account: rule(receivableAccount), debit: "Net + Vat" }
+      - { Account: rule(revenueAccount),    credit: "Net" }
+      - { Account: rule(vatAccount),        credit: "Vat", when: "Vat != 0" }
+```
+
+## expansions - child rows from a date span
+
+```yaml
+expansions:
+  - name: installments
+    from: Loan
+    into: LoanInstallment
+    unit: month                                     # day (default) | week | month
+    between: { start: startDate, end: endDate }
+    map: { dueDate: period }
+    spread: { total: principal, into: amount, round: 2 }   # last row absorbs the remainder
+    count: periods
+```
+
+A span change replaces the generated child set; never mix hand-entered rows into an expanded
+child.
+
+## rollups - denormalised parent totals
+
+```yaml
+rollups:
+  - { name: memberLoanCount, entity: Loan, via: member, field: loanCount }        # count
+  - { name: invoicePaid, entity: Allocation, via: SalesInvoice, field: paid,      # sum + balance + status
+      op: sum, of: amount, capacity: total, balance: balance,
+      status: Status, statusWhenFull: 7, statusWhenPartial: 6 }
+```
+
+Roll-ups compose transitively across a multi-level composition (leaf edit → mid total → top
+total); recomputation stops when values stop changing.
+
+## settlements - payment allocation
+
+```yaml
+settlements:
+  - name: autoAllocate
+    junction: SalesInvoiceCustomerPayment
+    invoice: SalesInvoice
+    payment: CustomerPayment
+    amount: amount
+    total: total
+    paid: paid
+    pot: amount
+    order: date                       # allocate oldest first
+    match: [Customer, Currency]
+    status: Status
+    payableStatuses: [3, 4, 6]
+```
+
+Generates the on-payment spread handler and an on-invoice pull delegate; pair with a `rollups`
+sum entry that maintains `paid`/`balance`/status.
+
+## reports - read-only aggregations
+
+```yaml
+reports:
+  - name: OrdersByMonth
+    source: Order
+    dimensions: ["month(orderDate)"]          # month()/year() bucket dates; relation.field joins
+    measures: ["count(*)", "sum(total)"]
+    filter: "total > 0"
+    chart: bar                                # render as a chart page
+    widget: { value: "sum(total)", at: { "month(orderDate)": now }, label: Revenue (this month) }
+  - name: TrialBalance
+    kind: balance                             # opening / period / closing debit+credit per dimension
+    source: JournalEntryItem
+    date: journalEntry.entryDate              # runtime From/To pickers
+    debit: debit
+    credit: credit
+    dimensions: [account.code, account.name]
+    filter: "journalEntry.status == 2"
+```
+
+In `filter:`, reference relations via `relation.field` (translated to a JOIN); a bare relation
+name passes into the SQL untranslated.
+
+## widgets - custom dashboard tiles
+
+```yaml
+widgets:
+  - { name: SystemHealth, kind: kpi,  url: /services/js/myapp/custom/health.js, icon: activity }
+  - { name: SalesFunnel,  kind: page, url: /services/web/myapp/custom/funnel/index.html }
+```
+
+## seeds - initial data
+
+```yaml
+seeds:
+  - name: statuses
+    entity: OrderStatus
+    rows:
+      - { id: 1, name: DRAFT }
+      - { id: 2, name: POSTED }
+  - name: cities
+    entity: City
+    rows:
+      - { id: 1, name: Sofia, Country: 34 }   # FK by the relation's authored name (case-sensitive)
+  - name: countries
+    entity: Country
+    file: data/countries.csv                  # large sets: developer-owned CSV in a subfolder
+  - name: uoms-bg
+    entity: UoM
+    language: bg                              # translations for a multilingual entity (_LANG)
+    rows:
+      - { id: 1, name: "Килограм" }
+```
+
+Row keys must match a field or relation name exactly (case-sensitive).
+
+## notifications - email on change
+
+```yaml
+notifications:
+  - name: welcomeMember
+    event: { onCreate: Member }               # exactly one of onCreate/onUpdate/onDelete
+    to: email                                 # a field, one-hop relation.field, or a literal
+    subject: "Welcome"
+    body: "Your membership is active."
+```
+
+## schedules - cron
+
+Per matching row, exactly one of `notify` or `generate`:
+
+```yaml
+schedules:
+  - name: monthlyTimesheets
+    cron: "0 0 1 1 * ?"
+    entity: Employee                          # the schedule's SOURCE must be local
+    where:
+      - { field: status, op: eq, value: ACTIVE }
+    generate:
+      to: EmployeeTimesheet                   # cross-model target via `uses:` alias
+      map: { Employee: id }
+      defaults: { Period: now }
+```
+
+## integrations - outbound HTTP
+
+```yaml
+integrations:
+  - { name: pushNewMember, event: { onCreate: Member }, method: POST, url: "https://api.example.com/members" }
+```
+
+## inbound - webhooks
+
+```yaml
+inbound:
+  - { name: leadHook, path: /webhooks/lead, create: Lead }
+```
+
+## permissions - roles
+
+```yaml
+permissions:
+  - { role: Librarian, can: [Member:read, Member:write, Loan:approve] }
+```
+
+## Print, tests and the shell (generated automatically)
+
+Every document (header-items) master also gets a standard `<Entity>.print` template (the Print
+button renders PDF via the document-template engine, per-language via CMS folders - see
+[Printing and documents](/help/intent/printing)), a `<name>.test` UI-test manifest, and its
+perspective in the generated SPA + the shared application shell (dashboard, Inbox, Documents,
+Reports, Settings including Region & Language).
+
+## Planned - recognised but not yet implemented
+
+- **`function: Calendar`** - reserved as an entity presentation role; rejected with a clear "not
+  yet available" message (the `view: calendar|range|slots` pages above are the current calendar
+  surface). Likewise other reserved `function` values for upcoming templates.
+- **`manyToMany`** - parsed but never materialized; the supported shape is the explicit
+  intermediate entity.
+- **Declarative glue actions beyond the current set**: publish/consume message,
+  `generateDocument` (PDF), `assign`, process-step events, inbound message/file events. Today's
+  implemented glue: triggers, decision/form resolvers, notifications, schedules, integrations,
+  inbound webhooks, rollups, settlements, expansions, generates, postings.
+- **Cross-model schedule source** - a schedule's `entity` must be local (the generate target may
+  be cross-model).
+- **`generates` completion hook** - flipping the source record's status after creating the
+  target is not yet expressible.
+- **Embedded calendar panel for a dependent composition child** inside its master page -
+  calendar views require a primary entity today.

--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -106,7 +106,9 @@ Values: `Document`, `DocumentItem`, `Master`, `Detail`, `List`, `Setting` (entit
 
 Row-level `exactlyOne` on every user write; document-level `itemsMin` / `itemsSumEqual` gated on
 a status transition - drafting stays unconstrained, and a failing transition aborts with the
-authored message.
+authored message. A REST create or update that violates a check returns **HTTP 400** with that
+message (via the SDK [`ValidationException`](../../sdk/db/validation-exception.md)); on a workflow
+transition the same check aborts the task completion.
 
 ```yaml
 - name: JournalEntry

--- a/docs/help/intent/generators.md
+++ b/docs/help/intent/generators.md
@@ -47,7 +47,7 @@ These cover every intent block defined today.
 - `PermissionIntentGenerator` to `<intent>.roles` - deduped roles; no `.access` URL constraints (those belong to the downstream template).
 - `CsvimIntentGenerator` to `<seed>.csvim` + `<seed>.csv` - platform-default CSVIM settings; project-qualified CSV path.
 - `PrintIntentGenerator` to `doc/Templates/<Entity>/Print/en/standard.print` - a printable document template for each document (header-items) master. Unlike the others it writes under `doc/` (not the project root) and is **generate-once** (create-if-absent), so a hand-adapted invoice is never regenerated over. See [printing and documents](/help/intent/printing).
-- `AppTestIntentGenerator` to `<intent>.test` - a UI-test manifest describing the generated entities (drawn from the `.model`), consumed by the app test runner.
+- the test generator to `<intent>.test` - a test manifest describing the generated entities (drawn from the `.model`), consumed by the test runner.
 
 See [the `.intent` file](/help/intent/intent-file) for the authoring shape each consumes, and [declarative glue](/help/intent/glue) for the `.glue` output.
 

--- a/docs/help/intent/generators.md
+++ b/docs/help/intent/generators.md
@@ -1,6 +1,6 @@
 ---
 title: Generators and generation
-description: The six model generators that turn an .intent into .edm / .bpmn / .form / .report / .roles / .csvim, the regeneration and scrub contract, and the .settings recipe.
+description: The model generators that turn an .intent into .edm / .bpmn / .glue / .form / .report / .roles / .csvim / .print / .test and the custom-action descriptors, plus the regeneration and scrub contract and the .settings recipe.
 ---
 
 # Generators and generation
@@ -13,12 +13,16 @@ Generate runs every registered generator in `@Order`, writes the derived model f
 | --- | --- | --- |
 | `entities` | `<intent>.edm` (XML) + `<intent>.model` (JSON twin) | 200 |
 | `processes[]` | `<process>.bpmn` (one per process) | 300 |
+| triggers, resolvers, glue | `<intent>.glue` | 350 |
 | `forms[]` | `<form>.form` (one per form) | 400 |
+| `actions[]` | `<action>.extension` + `<action>.js` (one per action) | 450 |
+| `generates[]` | `<name>.extension` + `<name>.js` (one per generate action) | 460 |
+| `transitions[]` | `<name>.extension` + `<name>.js` (+ a glue controller) | 470 |
 | `reports[]` | `<report>.report` (one per report) | 500 |
 | `permissions` | `<intent>.roles` | 600 |
 | `seeds[]` | `<seed>.csvim` + `<seed>.csv` (one pair per seed) | 700 |
 | document masters | `doc/Templates/<Entity>/Print/en/standard.print` | 800 |
-| triggers, resolvers, glue | `<intent>.glue` | (with the events template) |
+| `entities` (test manifest) | `<intent>.test` | 900 |
 
 These cover every intent block defined today.
 
@@ -38,10 +42,12 @@ These cover every intent block defined today.
 ### Forms, reports, roles, seeds
 
 - `FormIntentGenerator` to `<form>.form` - typed controls bound to the entity, action buttons coloured by name.
+- `ActionIntentGenerator` / `GeneratesIntentGenerator` / `TransitionsIntentGenerator` to `.extension` + `.js` pairs - the custom-action descriptors that put a button on a view or record: developer-defined pages ([`actions`](/help/intent/intent-file)), one-click document cloning ([`generates`](/help/intent/dsl-reference#generates-create-from)) and guarded status flips ([`transitions`](/help/intent/dsl-reference#transitions-guarded-status-flips)). Transitions and generates also contribute a server-side controller through the [`.glue`](/help/intent/glue) file.
 - `ReportIntentGenerator` to `<report>.report` - the Dirigible `.report` shape with a materialised SQL `query` (joins from `relation.field` paths, `WHERE` from `filter`, default-role `security`). All physical identifiers double-quoted for Postgres.
 - `PermissionIntentGenerator` to `<intent>.roles` - deduped roles; no `.access` URL constraints (those belong to the downstream template).
 - `CsvimIntentGenerator` to `<seed>.csvim` + `<seed>.csv` - platform-default CSVIM settings; project-qualified CSV path.
 - `PrintIntentGenerator` to `doc/Templates/<Entity>/Print/en/standard.print` - a printable document template for each document (header-items) master. Unlike the others it writes under `doc/` (not the project root) and is **generate-once** (create-if-absent), so a hand-adapted invoice is never regenerated over. See [printing and documents](/help/intent/printing).
+- `AppTestIntentGenerator` to `<intent>.test` - a UI-test manifest describing the generated entities (drawn from the `.model`), consumed by the app test runner.
 
 See [the `.intent` file](/help/intent/intent-file) for the authoring shape each consumes, and [declarative glue](/help/intent/glue) for the `.glue` output.
 
@@ -56,7 +62,7 @@ This is the most important operational rule of the intent layer:
 - Generation is **idempotent and diff-stable**: identical input produces byte-identical output; byte-identical content is not rewritten.
 - The **one exception** to root-only, always-rewrite is the print template ([printing and documents](/help/intent/printing)): it is written under `doc/` and **create-if-absent** (never regenerated over), because it is a hand-customized document rather than a derived model file. Everything under `doc/` is seeded into the CMS on publish.
 
-Output extensions are restricted to the model layer: `.edm` / `.model` / `.bpmn` / `.form` / `.report` / `.roles` / `.access` / `.glue` / `.dsm` / `.schema` / `.table` / `.view` / `.csvim` / `.csv`. Anything code-shaped (`*.ts`, `*.java`, `*.html`, `*.sql`, `*.css`) is the template engine's output and is never emitted by an intent generator. The one exception is the declarative-glue layer, which deliberately generates annotated client-Java - see [glue](/help/intent/glue).
+Output extensions are restricted to the model layer plus a few descriptor shapes: `.edm` / `.model` / `.bpmn` / `.form` / `.report` / `.roles` / `.access` / `.glue` / `.dsm` / `.schema` / `.table` / `.view` / `.csvim` / `.csv` / `.print` / `.test`, and the `.extension` + `.js` pair for custom-action descriptors (`actions` / `generates` / `transitions`). Anything else code-shaped (`*.ts`, `*.java`, `*.html`, `*.sql`, `*.css`) is the template engine's output and is never emitted by an intent generator. The one exception is the declarative-glue layer, which deliberately generates annotated client-Java - see [glue](/help/intent/glue).
 
 ## The `.settings` file
 

--- a/docs/help/intent/index.md
+++ b/docs/help/intent/index.md
@@ -43,6 +43,9 @@ Consequences:
        <intent>.roles                     permissions
        <intent>.glue                      triggers, resolvers, notifications, schedules, ...
        <seed>.csvim + <seed>.csv          seed data
+       <name>.extension + <name>.js       actions / generates / transitions (custom buttons)
+       doc/Templates/.../standard.print   printable document templates
+       <intent>.test                      app test manifest
 5. Generate once more, one level down: open a generated model and run the template engine, or let the editor chain it.
 6. Publish. The registry receives intent + models + generated code together; the per-artefact synchronizers bring the runtime live as for any project.
 ```

--- a/docs/help/intent/index.md
+++ b/docs/help/intent/index.md
@@ -64,6 +64,7 @@ Model-layer files at the project root are owned by the regeneration pass. **Do n
 
 - [The `.intent` file](/help/intent/intent-file) - the full YAML schema: entities, relations, processes, forms, reports, permissions, seeds, and the semantics that matter.
 - [Multi-model applications](/help/intent/multi-model) - split a domain into several intent modules that reference each other across models, reuse single master-data entities, and contribute to one shared shell.
+- [DSL reference](/help/intent/dsl-reference) - the quick index: one line + one snippet per supported construct, and the planned list.
 - [The Intent Editor](/help/intent/editor) - the split editor, the live diagram, validation, and Generate.
 - [The AI assistant](/help/intent/ai-assistant) - Claude proposes a patch to the intent; you accept or refine.
 - [Generators and generation](/help/intent/generators) - what each generator produces, the regeneration contract, and `.settings`.

--- a/docs/help/intent/index.md
+++ b/docs/help/intent/index.md
@@ -45,7 +45,7 @@ Consequences:
        <seed>.csvim + <seed>.csv          seed data
        <name>.extension + <name>.js       actions / generates / transitions (custom buttons)
        doc/Templates/.../standard.print   printable document templates
-       <intent>.test                      app test manifest
+       <intent>.test                      test manifest
 5. Generate once more, one level down: open a generated model and run the template engine, or let the editor chain it.
 6. Publish. The registry receives intent + models + generated code together; the per-artefact synchronizers bring the runtime live as for any project.
 ```

--- a/docs/help/intent/intent-file.md
+++ b/docs/help/intent/intent-file.md
@@ -126,6 +126,7 @@ fields:
 | `precision` / `scale` | override the DECIMAL default (16, 2): `{ name: rate, type: decimal, precision: 18, scale: 6 }` |
 | `calculatedOnCreate` / `calculatedOnUpdate` | an expression the generated repository assigns to the property on insert / update |
 | `calculatedActionOnCreate` / `calculatedActionOnUpdate` | a server-side action call-out - see "Calculated fields" |
+| `sensitive` | strip this field from the personal / partner surface and ignore it on their writes - see [Personal and partner surfaces](#personal-and-partner-surfaces) |
 
 Logical types: `string`, `text`, `integer`, `int`, `long`, `decimal`, `double`, `boolean`, `date`, `timestamp`, `uuid`. Generators map them to JDBC + EDM types. `text` becomes a CLOB; `uuid` becomes `VARCHAR(36)`.
 
@@ -134,6 +135,15 @@ Logical types: `string`, `text`, `integer`, `int`, `long`, `decimal`, `double`, 
 `audit: true` on an **entity** adds the four standard audit columns (`CreatedAt`, `CreatedBy`, `UpdatedAt`, `UpdatedBy`), populated by the platform's audit annotations.
 
 `multilingual: true` on an **entity** makes its string-typed properties translatable - see [multilingual](#multilingual-data-and-ui).
+
+`label:` on an **entity** synthesises a stored, read-only `Name` recomputed on every write, so lookups and dropdowns show a meaningful label instead of a raw id:
+
+```yaml
+- name: SalesInvoice
+  label: "{Number} - {Date|yyyy MMMM} - {Customer.name}"
+```
+
+Tokens are own fields or **one-hop** to-one relation properties (`{Customer.name}`); `|format` is a date pattern for temporal values. Deeper paths are rejected - compose by referencing the related entity's own label (`{Parent.Name}`). It is not allowed next to an authored `name` field, and a token must never reference a `sensitive` field.
 
 ### Control order
 
@@ -194,6 +204,28 @@ Composition is **opt-in** - this matches the Dirigible convention where most req
 ```
 
 `kind: setting` marks an entity as nomenclature / configuration. It is generated with `type="SETTING"`, which the template engine routes under the dashboard's global **Settings** perspective instead of giving it its own perspective. Any relation **targeting** a setting entity resolves its dropdown to the `Settings` perspective. Settings are still real entities (own table, seeds, FK columns) - only their UI placement differs. Default `kind` (omitted) is a regular managed entity.
+
+### Personal and partner surfaces
+
+On top of the regular controller (unaffected), an entity's records can be scoped to the logged-in user - the **My** shell at `/services/web/my/` - or to an external business partner - the **Partner** shell at `/services/web/partner/`.
+
+```yaml
+entities:
+  - name: Employee
+    identity: email                       # the string field matched against the login username
+  - name: Timesheet
+    relations:
+      - { name: Employee, kind: manyToOne, to: Employee, personal: true }   # the record owner
+    fields:
+      - { name: rate, type: decimal, sensitive: true }   # hidden + ignored on the personal surface
+```
+
+- **`identity: <field>`** on the owner entity names the string field (conventionally a unique e-mail) matched against the login username.
+- **`personal: true`** on a record-owning to-one relation generates an additional `<Entity>MyController` on the My shell: reads are filtered to the caller's mapped record, the owner FK is forced server-side on writes, and a foreign record returns 404. At most one `personal:` relation per entity; the target must declare `identity`; never put it on a composition parent - composition children inherit the owner's scope through their parent.
+- **`partner: true`** is the exact mirror for EXTERNAL parties (customers, suppliers) on the Partner shell, whose perspectives register on the disjoint `application-partner-perspectives` extension point and are gated by the IdP roles (`Customer` / `Supplier` / `Partner`). An entity can carry both `personal:` (a staff owner) and `partner:` (an external owner) at once.
+- **`sensitive: true`** on a field (never the PK, the identity field, or the owner FK) strips it from the personal and partner responses and ignores it on their writes - use it for billing rates and amounts the owner must not see.
+
+A user task can also be routed to the record owner's Inbox with the literal `assignee: personal` (it resolves the owner through the `personal:` relation).
 
 ### Cross-model references (`uses`)
 

--- a/docs/sdk/db/index.md
+++ b/docs/sdk/db/index.md
@@ -18,6 +18,7 @@ The module covers two styles of database interaction:
 
 - [`Database`](./database.md) - primary entry point for relational-database access; JSON helpers, raw JDBC, sequences, and data-source lookup.
 - [`Store`](./store.md) - untyped Hibernate-backed CRUD over named entities, exchanging data as JSON.
+- [`ValidationException`](./validation-exception.md) - thrown by client-side domain logic (a repository's declarative checks, a capacity guard, or hand-written validation) to signal that a well-formed request violates a business rule; the controller runtime maps it to HTTP 400.
 - [Decorators](./decorators.md) - annotation set used to declare persistent entities:
   - `@Entity` - marks a class as a persistent entity
   - `@Table` - overrides the physical table name

--- a/docs/sdk/db/validation-exception.md
+++ b/docs/sdk/db/validation-exception.md
@@ -1,0 +1,46 @@
+# ValidationException
+
+## Overview
+
+::: tip Module
+- package: `org.eclipse.dirigible.sdk.db`
+- source: [db/ValidationException.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/db/ValidationException.java)
+:::
+
+`ValidationException` is thrown by client-side domain logic to signal that a **well-formed** request violates a **business rule** - as opposed to a malformed request or an unexpected server fault. It is the exception a generated repository raises for a declarative `checks:` gate or a capacity guard, and the one your own hand-written validation should throw when it rejects an otherwise-valid write.
+
+The Java controller runtime maps it to **HTTP `400 Bad Request`** carrying the exception message, so a user-fixable validation surfaces as a client error instead of an opaque `500`. Raised on a non-HTTP path (for example a BPMN service task), it simply fails that unit of work with its message, the same as any other unchecked exception.
+
+### Key Features:
+- **Layer-clean**: thrown from the persistence/domain layer, it carries no web dependency - the HTTP-status mapping lives once in the controller dispatcher, not in every controller.
+- **Consistent 400 mapping**: every generated (and hand-written) client controller reports it as `400` with the authored message, matching the row-level check behaviour.
+- **Message-carrying**: the constructor message is the reason returned to the caller - write it for the end user.
+
+### When it is raised for you
+
+- A document-level `checks:` violation (`itemsMin`, `itemsSumEqual`) on a gated status transition.
+- A capacity guard on a balance roll-up rejecting an over-capacity child write.
+
+In both cases a REST create/update returns `400`; on a workflow transition the same exception aborts the task completion.
+
+### Example Usage:
+```java
+import org.eclipse.dirigible.sdk.component.Component;
+import org.eclipse.dirigible.sdk.db.ValidationException;
+
+@Component
+public class TransferValidator {
+
+    public void validate(TransferEntity transfer) {
+        if (transfer.getAmount() == null || transfer.getAmount().signum() <= 0) {
+            // Surfaces to the caller as HTTP 400 with this message.
+            throw new ValidationException("Transfer amount must be greater than zero");
+        }
+    }
+}
+```
+
+## Constructors
+
+- `ValidationException(String message)` - the user-facing reason the request was rejected.
+- `ValidationException(String message, Throwable cause)` - the same, wrapping an underlying cause.


### PR DESCRIPTION
Documentation for the intent-driven development surface.

- **Intent DSL reference** page (`docs/help/intent/dsl-reference.md`) covering every supported construct + the planned list, with in-page anchors fixed for VitePress' slug rules.
- **SDK `ValidationException`** (`docs/sdk/db/`): new reference page for `org.eclipse.dirigible.sdk.db.ValidationException` — thrown by client-side domain logic (declarative `checks:`, capacity guards, hand-written validation) to signal a business-rule violation, mapped by the controller runtime to **HTTP 400**. Listed in the db module index and the SDK sidebar.
- **`checks:` → 400**: the DSL reference now states that a `checks:` violation returns HTTP 400 with the authored message over REST (and aborts the task completion on a workflow transition), cross-linking the SDK page.

Verified with `npm run docs:build` (VitePress dead-link check passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)