### PR TITLE
docs(intent): sync intent DSL docs with the parser implementation

### DIFF
--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -18,9 +18,11 @@ complete worked example.
 | [`checks`](#checks-declarative-validations) | cross-field / cross-line validations |
 | [`immutableWhen` / `immutable`](#immutablewhen-immutable-user-write-immutability) | 409 on user writes in a status / append-only snapshots |
 | [`hierarchy` / `leafOnly`](#hierarchy-leafonly-tree-entities) | tree entities, leaf-only references |
+| [`personal` / `partner`](#personal-partner-row-scoped-surfaces) | per-user and per-partner row-scoped surfaces (+ `sensitive` stripping) |
 | [`multilingual` / `languages`](#multilingual-translated-master-data) | `_LANG` tables + read-time translation overlay |
 | [calculated fields](#calculated-fields-actions) | server+UI-evaluated expressions, date functions, Java call-outs |
 | [`view`](#view-calendar-range-slots) | calendar / range / slot-booking pages |
+| [`documentItemsLayout: chat`](#documentitemslayout-chat-conversation-threads) | render a document's items as a chat thread |
 | [`uses`](#uses-cross-model-references) | reuse entities owned by another intent model |
 | [`processes`](#processes-workflows) | BPM workflows with user tasks, decisions, delegates |
 | [`forms`](#forms-task-ui) | task data-entry pages |
@@ -99,8 +101,9 @@ Optional and authoritative when set; inferred from structure otherwise.
   function: DocumentItem       # its line items (no "*Item" naming needed)
 ```
 
-Values: `Document`, `DocumentItem`, `Master`, `Detail`, `List`, `Setting` (entity);
-`DocumentTitle` (field); `EntityStatus` (relation).
+Values: `Document`, `DocumentItem`, `Master`, `Detail`, `List`, `Setting`, `Calendar` (entity -
+`Calendar` is the role alias for `view: calendar`); `DocumentTitle` (field); `EntityStatus`
+(relation). `Board` / `Gantt` / `Timeline` are reserved and rejected until those templates ship.
 
 ## checks - declarative validations
 
@@ -186,6 +189,47 @@ out.
   slots: { start: startTime }
 ```
 
+## personal / partner - row-scoped surfaces
+
+A record-owning to-one relation can scope an entity to the logged-in staff user or external
+partner, adding a second generated controller with server-side row-level filtering.
+
+```yaml
+- name: Employee
+  identity: email                    # field matched against the login username
+- name: Expense
+  relations:
+    - { name: Employee, kind: manyToOne, to: Employee, personal: true }   # staff owner
+    - { name: Supplier, kind: manyToOne, to: Supplier, partner: true }    # external-partner owner
+  fields:
+    - { name: rate, type: decimal, sensitive: true }   # stripped from the scoped surfaces
+```
+
+`identity` (on the person/partner entity) declares how a login maps to a record. `personal: true`
+(at most one per entity) generates an `<Entity>MyController` filtered to the caller's owned records
+on the personal shell; `partner: true` the mirror `<Entity>PartnerController` on the Partner shell
+(`/services/web/partner/`, gated by the Customer / Supplier / Partner IdP roles). A `sensitive:
+true` field is stripped from those scoped responses and ignored on their writes (enforced
+server-side, not merely hidden). The regular controller is unaffected; an entity may carry both.
+
+## documentItemsLayout: chat - conversation threads
+
+A document master can render its line-items child as a chat thread (message bubbles + a composer)
+instead of the editable items table - support cases, tickets, comment threads. The header, status
+pill, process tasks and print stay as in a normal document.
+
+```yaml
+- name: Case
+  function: Document
+  documentItemsLayout: chat
+- name: CaseMessage
+  function: DocumentItem
+  audit: true                                    # bubble author + timestamp come from audit
+  fields:
+    - { name: body,     type: text,    messageBody: true }      # the bubble text (exactly one)
+    - { name: internal, type: boolean, messageInternal: true }  # internal memo (hidden from partners)
+```
+
 ## uses - cross-model references
 
 Entities owned by another intent model are referenced read-only (a projection + FK + dropdown -
@@ -224,7 +268,10 @@ processes:
 Service-task shapes: `setField` / `setRelationField` (generated handlers), `delegate` (a reusable
 hand-written client `JavaDelegate` with injected `fields`). Decisions may test `relation.field`
 paths (`customer.creditLimit > 10000`) - resolvers are generated. Tasks surface in the Inbox and
-inline on the record's page.
+inline on the record's page. A user task's `assignee` is a role / candidate-group name, or the
+literal `assignee: personal` to route the task to the **record owner's** Inbox (requires the
+trigger entity to declare a `personal:` relation - see
+[personal / partner](#personal-partner-row-scoped-surfaces)).
 
 ## forms - task UI
 
@@ -455,12 +502,17 @@ Reports, Settings including Region & Language).
 - **`manyToMany`** - parsed but never materialized; the supported shape is the explicit
   intermediate entity.
 - **Declarative glue actions beyond the current set**: publish/consume message,
-  `generateDocument` (PDF), `assign`, process-step events, inbound message/file events. Today's
-  implemented glue: triggers, decision/form resolvers, notifications, schedules, integrations,
-  inbound webhooks, rollups, settlements, expansions, generates, postings.
+  event-driven `generateDocument` (produce a PDF on an event), process-step events, inbound
+  message/file events. Today's implemented glue: triggers, decision/form resolvers, notifications,
+  schedules (notify + generate), integrations, inbound webhooks, rollups, settlements, expansions,
+  generates, postings.
 - **Cross-model schedule source** - a schedule's `entity` must be local (the generate target may
   be cross-model).
 - ~~`generates` completion hook~~ - landed: `sourceStatus` flips the source's status after the
   target is created.
-- **Embedded calendar panel for a dependent composition child** inside its master page -
-  calendar views require a primary entity today.
+- ~~Embedded calendar panel for a dependent composition child~~ - landed: a calendar-view
+  composition child renders as an embedded calendar in its master's detail pane (a `scope:`
+  relation filters and prefills by the parent).
+- ~~Owner-based user-task assignment~~ - landed: `assignee: personal` routes a task to the record
+  owner. Arbitrary resolver-path assignment (an assignee resolved from any relation walk) is still
+  planned.

--- a/docs/help/intent/glue.md
+++ b/docs/help/intent/glue.md
@@ -60,7 +60,27 @@ schedules:
       body: "This order is stale."
 ```
 
-Generates a `gen/events/<Name>Job.java` `@Scheduled` `JobHandler` that runs a typed `Criteria` query (`where` to typed conditions, `CURRENT_DATE` / `CURRENT_TIMESTAMP` to now) and performs the per-row `notify` (same relation-load + interpolation as notifications). The action is `notify` only for now.
+Generates a `gen/events/<Name>Job.java` `@Scheduled` `JobHandler` that runs a typed `Criteria` query (`where` to typed conditions, `CURRENT_DATE` / `CURRENT_TIMESTAMP` to now) and performs, per matching row, **exactly one of `notify` or `generate`** (the `notify` form uses the same relation-load + interpolation as notifications).
+
+The `generate` variant creates a record through the **target's** repository (so numbering, status init and calculated fields fire); the target may be cross-model via a `uses:` alias, and it may fan out `children` (one child per matching entity, or per working day of the period):
+
+```yaml
+schedules:
+  - name: monthlyTimesheets
+    cron: "0 0 1 1 * ?"
+    entity: Employee
+    where:
+      - { field: status, op: eq, value: ACTIVE }
+    generate:
+      to: EmployeeTimesheet          # cross-model target via a uses: alias
+      map: { Employee: id }
+      defaults: { Period: now }
+      children:
+        - to: EmployeeDayAllocation
+          parent: EmployeeTimesheet
+          forEach: { days: workingDays }   # one child per working day
+          dayField: day
+```
 
 ## integrations
 
@@ -103,25 +123,46 @@ rollups:
 
 Generates two `gen/events/<Name>RollupOn{Create,Delete}.java` `@Listener`s on the child's create / delete topics that recompute the affected parent's count via a typed `Criteria` and write it back. Recompute-on-event (self-healing), so it is **eventually consistent, not transactionally exact** under heavy concurrency. It counts all children (no `where` filter yet) and tracks create / delete only (not re-parenting on update).
 
+With `op: sum` the roll-up instead keeps `field` equal to the sum of the children's `of` field, and can maintain a `balance` (= `capacity - sum`) and flip a `status` relation to `statusWhenFull` / `statusWhenPartial` - the invoice paid / balance / PAID-PARTIAL pattern. Sum roll-ups also compose transitively across a multi-level composition (leaf edit to mid total to top total). See [rollups in the DSL reference](/help/intent/dsl-reference#rollups-denormalised-parent-totals).
+
+```yaml
+rollups:
+  - { name: invoicePaid, entity: Allocation, via: SalesInvoice, field: paid,
+      op: sum, of: amount, capacity: total, balance: balance,
+      status: Status, statusWhenFull: 7, statusWhenPartial: 6 }
+```
+
 ## Lifecycle triggers
 
 A process `trigger` (start a process on an entity event) is the original glue and is documented with [processes](/help/intent/intent-file#processes), including the configurable `businessKey` and `businessKeyStrategy: timestamp`. Decision **resolvers** (load a related entity's field at a gateway) are also glue, emitted into `<intent>.glue`.
 
 ## What one intent can declare today
 
+The event-then-action glue above, plus the data-flow glue documented in the
+[DSL reference](/help/intent/dsl-reference) - [`settlements`](/help/intent/dsl-reference#settlements-payment-allocation),
+[`expansions`](/help/intent/dsl-reference#expansions-child-rows-from-a-date-span),
+[`generates`](/help/intent/dsl-reference#generates-create-from) and
+[`postings`](/help/intent/dsl-reference#postings-source-document-to-ledger) - are all generated as the same annotated client-Java under `gen/events`.
+
 | Glue | Status |
 | --- | --- |
 | Lifecycle triggers (process start, `when` guard, business key + timestamp strategy) | implemented |
-| Decision resolvers (`relation.field` at a gateway) | implemented |
+| Decision / form resolvers (`relation.field` at a gateway or on a task form) | implemented |
 | Notifications (email; literal / field / one-hop relation; `when`) | implemented |
-| Schedules (cron to typed-`Criteria` query to per-row notify) | implemented |
+| Schedules (cron to typed-`Criteria` query; per-row `notify` or `generate`) | implemented |
 | Integrations (event to `HttpClient`) | implemented |
 | Inbound webhooks (`@Controller` ingest to entity) | implemented |
-| Rollups (recompute a parent counter) | implemented |
-| Documents (PDF) | planned |
-| Status lifecycle / state machine | planned |
-| Audit / history | planned |
-| Dynamic user-task assignment | planned |
+| Rollups (count, and sum + balance + status) | implemented |
+| Settlements (auto-allocate payments across open invoices) | implemented |
+| Expansions (generate child rows from a date span) | implemented |
+| Generates (one-click document-from-document create) | implemented |
+| Postings (source document to balanced local document) | implemented |
+| Owner-based user-task assignment (`assignee: personal`) | implemented |
+| Standard per-document PDF print templates | implemented (see [Printing](/help/intent/printing)) |
+| Event-driven document generation (produce a PDF on an event) | planned |
+| Status lifecycle / declarative state machine | planned |
+| Audit history (shadow `<Entity>History` entity; audit *columns* via `audit: true` ship today) | planned |
+| Arbitrary resolver-path task assignment (beyond `assignee: personal`) | planned |
 
 ## Guardrails
 


### PR DESCRIPTION
## What

Reconciles the `/help/intent/` pages with what the intent `IntentParser` (in `eclipse-dirigible/dirigible`) actually accepts. **The parser + model POJOs are the single source of truth.** Two pages had drifted; the rest were already accurate.

## Why

The DSL reference and glue pages under-described several shipped capabilities and still listed a few implemented features as "planned". The docs are the public contract for authoring `.intent` files, so drift here misleads users into thinking capabilities don't exist (calendar, personal/partner surfaces, scheduled record generation, sum rollups).

## Changes

### `dsl-reference.md`
- Add **`Calendar`** to the `function` values (it is the role alias for `view: calendar`); note `Board` / `Gantt` / `Timeline` are the reserved-and-rejected functions.
- Document **`assignee: personal`** on user tasks (routes the task to the record owner's Inbox).
- Add a **personal / partner** section (`identity` / `personal` / `partner` / `sensitive` row-scoped surfaces) - previously undocumented.
- Add a **`documentItemsLayout: chat`** section (conversation-thread line items).
- Planned section: mark *embedded calendar for a composition child* and *owner-based user-task assignment* as **landed**; keep the genuine gaps.

### `glue.md`
- **schedules**: document the `generate` variant (+ `children` fan-out) - it was described as "notify only".
- **rollups**: document the `sum` + `capacity` + `balance` + `status` form (invoice paid/balance/PAID-PARTIAL).
- Rewrite the "what one intent can declare today" table: add **settlements, expansions, generates, postings, owner-based assignment, standard PDF print** as implemented; correct the planned rows.

## Verification

`npm run docs:build` passes (all pages render). Every added/changed statement checked against `IntentParser.java`, the `model/*.java` POJOs and the generators (`validateViews`, `CalendarIntent`/`SlotsIntent`, `validateTaskFormActions` for `assignee: personal`, the rollup/schedule/settlement/expansion/generate/posting support classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)