### PR TITLE
docs(intent): month/week field types + postings reverses (red storno)

### DIFF
--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -74,6 +74,8 @@ entities:
 - { name: code,  type: string, unique: true, length: 30 }              # UNIQUE constraint
 - { name: uuid,  type: uuid, major: false }                            # off the list table
 - { name: total, type: decimal, precision: 18, scale: 2, readOnly: true }
+- { name: period, type: month }                                        # YYYY-MM month picker
+- { name: sprint, type: week }                                         # YYYY-Www ISO-week picker
 - { name: number, type: string, function: DocumentTitle }              # the document title/number
 - { name: Currency, kind: manyToOne, to: Currency, size: 4 }           # form width (12-col grid)
 - { name: Payment, kind: manyToOne, to: Payment, show: [date, number] }  # extra read-only lookup columns
@@ -362,6 +364,28 @@ postings:
       - { Account: rule(receivableAccount), debit: "Net + Vat" }
       - { Account: rule(revenueAccount),    credit: "Net" }
       - { Account: rule(vatAccount),        credit: "Vat", when: "Vat != 0" }
+```
+
+A second posting can **reverse** the first (red storno) when the source document is voided - pair it
+with the [`transitions`](#transitions-guarded-status-flips) void that flips the source into its void
+status. The reversal inherits `creates` / `backReference` / `rule` / `map` / `items` from the sibling
+it names, negates every item amount on the **same** side (a red storno, not a swap of debit/credit),
+links back to the original through the `storno` self-relation, and is fail-soft (nothing to reverse
+when the source was never posted).
+
+```yaml
+postings:
+  - name: docPosting
+    event: { onTransition: Doc, when: "Status == 2" }   # posted
+    creates: Entry
+    backReference: Doc
+    items:
+      - { debit: "Amount" }
+      - { credit: "Amount" }
+  - name: docStorno
+    event: { onTransition: Doc, when: "Status == 3" }   # voided
+    reverses: docPosting                                 # inherit + negate the sibling's items
+    storno: Storno                                       # the self-link field on the created Entry
 ```
 
 ## expansions - child rows from a date span

--- a/docs/help/intent/intent-file.md
+++ b/docs/help/intent/intent-file.md
@@ -128,7 +128,7 @@ fields:
 | `calculatedActionOnCreate` / `calculatedActionOnUpdate` | a server-side action call-out - see "Calculated fields" |
 | `sensitive` | strip this field from the personal / partner surface and ignore it on their writes - see [Personal and partner surfaces](#personal-and-partner-surfaces) |
 
-Logical types: `string`, `text`, `integer`, `int`, `long`, `decimal`, `double`, `boolean`, `date`, `timestamp`, `uuid`. Generators map them to JDBC + EDM types. `text` becomes a CLOB; `uuid` becomes `VARCHAR(36)`.
+Logical types: `string`, `text`, `integer`, `int`, `long`, `decimal`, `double`, `boolean`, `date`, `timestamp`, `uuid`, `month`, `week`. Generators map them to JDBC + EDM types. `text` becomes a CLOB; `uuid` becomes `VARCHAR(36)`. `month` (a `YYYY-MM` string) and `week` (a `YYYY-Www` ISO-week string) are stored as short `VARCHAR`s and render as the Harmonia month / week pickers.
 
 **Primary keys must be an integer type** (`integer` / `int` / `long`). The Dirigible convention is an integer auto-increment id, and a non-integer auto-increment column is invalid SQL - the parser rejects a `uuid` or string PK. `uuid` is fine for non-PK fields.
 


### PR DESCRIPTION
Documents two intent DSL features merged into the platform this cycle:

- **`month` / `week` field types** (dirigible #6312) — stored as `YYYY-MM` / `YYYY-Www` `VARCHAR` strings, rendered as the Harmonia month / week pickers. Added to the type lists in `dsl-reference.md` and `intent-file.md`.
- **`postings: reverses` / `storno`** (dirigible #6308) — the red-storno reversal paired with a `transitions` void: inherits the sibling posting, negates each item amount on the same side, links to the original, fail-soft. Added to the `postings` section of `dsl-reference.md`.

Verified with a full `vitepress build` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)