### PR TITLE
docs(intent): wait step + userTask timeout/expire boundary timers (BPM events wave 1)

### DIFF
--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -25,7 +25,7 @@ complete worked example.
 | [`view`](#view-calendar-range-slots) | calendar / range / slot-booking pages |
 | [`documentItemsLayout: chat`](#documentitemslayout-chat-conversation-threads) | render a document's items as a chat thread |
 | [`uses`](#uses-cross-model-references) | reuse entities owned by another intent model |
-| [`processes`](#processes-workflows) | BPM workflows with user tasks, decisions, delegates |
+| [`processes`](#processes-workflows) | BPM workflows with user tasks, decisions, delegates, waits and boundary timers |
 | [`forms`](#forms-task-ui) | task data-entry pages |
 | [`actions`](#actions-custom-buttons) | developer-defined buttons opening custom pages |
 | [`generates`](#generates-create-from) | one-click document-from-document cloning |
@@ -291,6 +291,27 @@ inline on the record's page. A user task's `assignee` is a role / candidate-grou
 literal `assignee: personal` to route the task to the **record owner's** Inbox (requires the
 trigger entity to declare a `personal:` relation - see
 [personal / partner](#personal-partner-row-scoped-surfaces)).
+
+A running process can also **observe the outside world**:
+
+```yaml
+steps:
+  - name: review
+    kind: userTask
+    args:
+      assignee: reviewer
+      timeout: { after: P3D, then: remind }              # non-cancelling reminder / SLA escalation
+      expire:  { until: validUntil, then: markExpired }  # cancelling, date-field-driven expiry
+      next: awaitReply
+  - { name: awaitReply, kind: wait, args: { onCreate: CaseMessage, via: case, when: "internal == false", next: work } }
+```
+
+A **`wait`** step parks the flow on a message intermediate catch event until an entity event resumes
+it (a reply arrives, a payment lands, a goods receipt posts) - the generated listener correlates on
+the trigger entity's stamped `ProcessId`, through the `via:` back-reference when the event entity is
+a different one. **`timeout:`** / **`expire:`** are boundary timers on a user task: `after:` an
+ISO-8601 duration for a non-cancelling reminder, `until:` a `date`/`timestamp` field re-read at task
+entry for a cancelling expiry. Details: [processes](/help/intent/intent-file#processes).
 
 ## forms - task UI
 

--- a/docs/help/intent/glue.md
+++ b/docs/help/intent/glue.md
@@ -136,6 +136,13 @@ rollups:
 
 A process `trigger` (start a process on an entity event) is the original glue and is documented with [processes](/help/intent/intent-file#processes), including the configurable `businessKey` and `businessKeyStrategy: timestamp`. Decision **resolvers** (load a related entity's field at a gateway) are also glue, emitted into `<intent>.glue`.
 
+## Waits and boundary timers
+
+The process-side "observe the outside world" primitives ([`wait`, `timeout:`, `expire:`](/help/intent/intent-file#processes)) each generate their own glue class under `gen/events`:
+
+- a **wait listener** (`<Process><Step>Wait.java`, the `waits` collection) - a `MessageHandler` on the event entity's topic that applies the `when:` guard, resolves the record carrying the parked instance's `ProcessId` (through the `via:` back-reference, or the event record itself), and correlates the catch event's message fail-soft;
+- an **expire date loader** (`Load<Process><Task>Expire.java`, the `timerLoaders` collection) - a `JavaDelegate` inserted before the user task that re-reads the trigger entity's date field at task entry and publishes the `java.util.Date` process variable the cancelling boundary timer arms from.
+
 ## What one intent can declare today
 
 The event-then-action glue above, plus the data-flow glue documented in the
@@ -158,6 +165,8 @@ The event-then-action glue above, plus the data-flow glue documented in the
 | Generates (one-click document-from-document create) | implemented |
 | Postings (source document to balanced local document) | implemented |
 | Owner-based user-task assignment (`assignee: personal`) | implemented |
+| Waits (`wait` step - park on an entity event, correlate by `ProcessId`) | implemented |
+| Boundary timers (userTask `timeout:` reminder / `expire:` date-driven withdrawal) | implemented |
 | Standard per-document PDF print templates | implemented (see [Printing](/help/intent/printing)) |
 | Event-driven document generation (produce a PDF on an event) | planned |
 | Status lifecycle / declarative state machine | planned |

--- a/docs/help/intent/intent-file.md
+++ b/docs/help/intent/intent-file.md
@@ -280,11 +280,49 @@ processes:
 
 Generates one `<process>.bpmn` (Flowable-flavoured BPMN 2.0) plus the diagram interchange so the BPMN modeler renders it.
 
-Step kinds: `userTask`, `serviceTask`, `decision`, `script`, `end`.
+Step kinds: `userTask`, `serviceTask`, `decision`, `script`, `wait`, `end`.
 
 **Decision steps**: `if` + `then` are mandatory, `else` optional. `then` / `else` must name a declared step or the literal `end`; the parser validates this, so a typo fails at parse time rather than producing a Flowable reject. Without `else`, the gateway default falls through to the next step.
 
 A decision condition can walk **one hop** off the trigger entity (`customer.creditLimit > 10000`): the generator inserts a resolver service task before the gateway that loads the related entity and rewrites the condition to the resolved variable.
+
+### wait - park the process on a data event
+
+A `wait` step parks the process on a BPMN **message intermediate catch event** until an entity lifecycle event resumes it - a support case waiting for the requester's reply, a dunning flow waiting for a payment, an order flow waiting for its goods receipt:
+
+```yaml
+steps:
+  - { name: requestInfo, kind: serviceTask, args: { setRelationField: Status, value: 4, next: awaitReply } }
+  - { name: awaitReply,  kind: wait, args: { onCreate: CaseMessage, via: case, when: "internal == false", next: work } }
+  - { name: work,        kind: userTask, args: { assignee: agent, form: WorkCase } }
+```
+
+- `onCreate | onUpdate: <Entity>` (exactly one; `onDelete` is rejected - a deleted record cannot resume a wait) names the resuming event of a declared entity.
+- `via: <relation>` - when the event entity is not the trigger entity itself: the **event** entity's to-one relation that walks to the trigger entity (here `CaseMessage.case`). Omitted when the event entity *is* the trigger entity; same-model relations only.
+- `when:` - the single-comparison guard over the **event record** (`field ==|!= literal`), so e.g. an internal note does not resume the wait.
+
+The generated glue is a `MessageHandler` on the event entity's topic that resolves the record carrying the parked instance's `ProcessId` (through `via:`, or the event record itself) and calls `Process.correlateMessageEvent(processId, message)`. Correlation rides the `ProcessId` the trigger listener already writes back - which is why a `wait` requires the process to declare a `trigger:`. **Fail-soft:** no `ProcessId`, no matching parked instance, or an instance already past the wait is a no-op, never an error.
+
+### timeout / expire - boundary timers on a user task
+
+Two optional map attributes on a `userTask`'s args give generated flows a notion of time. Both route `then` like a decision branch (a declared step or `end`; route the main flow around the branch steps with `next`):
+
+```yaml
+steps:
+  - name: approve
+    kind: userTask
+    args:
+      assignee: approver
+      form: ApproveQuotation
+      timeout: { after: P3D, then: remind }              # non-cancelling: the task STAYS
+      expire:  { until: validUntil, then: markExpired }  # cancelling: the task is WITHDRAWN
+      next: done
+```
+
+- `timeout: { after: <ISO-8601 duration>, then: <step> }` - a **non-cancelling** boundary timer (`PT4H`, `P3D`): after the duration the `then` branch runs (a reminder / SLA escalation) while the task stays claimable.
+- `expire: { until: <field>, then: <step> }` - a **cancelling** boundary timer driven by a `date` / `timestamp` field of the trigger entity (a quotation's `validUntil`): when the moment passes, the task is withdrawn and the flow continues at `then`.
+
+The expire date is **re-read at task entry** by a generated loader delegate inserted before the task, so editing the date mid-flow moves the timer. A `date` field names the *last valid day* - the timer fires at the start of the day after it; a `timestamp` fires at its instant; a `null` value arms a far-future date so the timer never effectively fires. The Flowable async job executor (always active) runs the timer jobs - no configuration needed.
 
 ### trigger
 


### PR DESCRIPTION
Documents the intent `processes:` DSL's first BPM-event wave, shaped in eclipse-dirigible/dirigible#6327 and eclipse-dirigible/dirigible#6328:

- **`intent-file.md`** — two new subsections under *processes*: **`wait`** (park the flow on a message intermediate catch event resumed by an entity lifecycle event; the `via:` back-reference correlation contract on the stamped `ProcessId`; the `when:` guard; fail-soft rules) and **`timeout:` / `expire:`** (non-cancelling reminder/SLA vs cancelling date-field-driven boundary timers; the date re-read at task entry; last-valid-day semantics for `date` fields).
- **`dsl-reference.md`** — the *processes* summary gains the observe-the-outside-world example + prose; the capability index row now mentions waits and boundary timers.
- **`glue.md`** — the new generated glue classes (`<Process><Step>Wait` in the `waits` collection, `Load<Process><Task>Expire` in `timerLoaders`) and two *implemented* rows in the status table.

**Merge after** eclipse-dirigible/dirigible#6330 — the docs describe behavior that ships with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
