### PR TITLE
docs(intent): aggregates, guard checks with outcomes, and posts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,23 @@ The Monitoring perspective is at `ide/perspectives/monitoring.md` + three views 
 - **Cross-links are absolute** — `/help/...`, `/api/...`, `/sdk/...`, `/sdks/...`. `ignoreDeadLinks: true` is on; that masks broken links at build time, so run the dead-link scanner manually (see "Operational scripts" below) before publishing significant changes.
 - **Frontmatter on every page** — `---\ntitle: ...\ndescription: ...\n---`. If `description` starts with `@` (e.g. `@Inject`) quote it: `description: "@Inject + @Repository"`. Bare `@` at the start of a YAML scalar fails to parse.
 
+## Intent spec docs sync (intentfile.org + this site)
+
+`intentfile.org` (repo `IntentFile/intentfile.github.io`) is THE intent **specification** - a
+vendor-neutral, normative doc site. Its DSL is implemented by the `engine-intent` reference
+implementation in the platform. This site (`dirigible.io`) carries the platform-branded intent
+docs under `/help/intent/`.
+
+**Directive (normative):** any intent DSL addition/change updates BOTH sites in the same effort:
+
+- **`intentfile.org`** - open a PR and **leave it OPEN (do NOT merge)**; the maintainer
+  reviews/merges the public spec. Neutral wording ONLY: no vendor/platform names (no Dirigible /
+  Eclipse / product names), and NEVER a `CLAUDE.md` / `MEMORY.md` or any AI/meta file in that repo.
+- **`dirigible.io`** (this repo) - open a PR and **merge it**.
+
+Derive the neutral wording for the spec from the platform docs (or vice versa); the two must stay
+in lockstep with the parser/generators.
+
 ## SDK organisation
 
 The two SDKs are siblings, not parent/child:

--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -141,6 +141,48 @@ authored message.
     - { kind: exactlyOne, fields: [debit, credit], message: "Exactly one of debit/credit" }
 ```
 
+## checks: kind: guard - precondition over an aggregate
+
+```yaml
+- name: StockMovement
+  checks:
+    - kind: guard
+      aggregate: onHand                 # an `aggregates` entry whose `of` is THIS entity
+      minimum: 0                        # recomputed total (prior rows + this row) stays >= minimum
+      message: "Insufficient stock"
+      enabledBy: BLOCK_NEGATIVE_STOCK   # optional: enforced only while the config key is "true"
+- name: SalesOrder
+  checks:
+    - kind: guard
+      aggregate: openExposure
+      minimum: 0
+      outcome: task                     # accept the write, mark it for a human step
+      marker: withinCredit
+- name: LeaveRequest
+  checks:
+    - kind: guard
+      aggregate: remaining
+      minimum: 0
+      outcome: reject                   # accept the write, file it already rejected
+      setStatus: 4
+```
+
+| `outcome` | Companion | A violating write |
+| --- | --- | --- |
+| `block` (default) | - | throws `ValidationException`, mapped to 4xx; nothing stored |
+| `task` | `marker:` boolean field | stored; the marker is set false (true whenever the guard holds) |
+| `reject` | `setStatus:` status seed id | stored; the `function: EntityStatus` FK is set to that value |
+
+Emitted into the generated repository's save and update paths. The total is recomputed
+SYNCHRONOUSLY from the guarded entity's own rows for the incoming key-tuple (excluding the row being
+updated), not read from the materialised aggregate target, so the decision cannot race the aggregate
+handler. Guard and aggregate are therefore two independent computations of the same total, and the
+guard is the authoritative one.
+
+`outcome: task` stamps a flag; it does not create or route to a task. A process `decision` step
+reads the marker and routes the record. `outcome: reject` requires an `EntityStatus` relation. A
+companion attribute belonging to another outcome is a generation error, not ignored.
+
 ## immutableWhen / immutable - user-write immutability
 
 ```yaml
@@ -478,6 +520,62 @@ rollups:
 
 Roll-ups compose transitively across a multi-level composition (leaf edit → mid total → top
 total); recomputation stops when values stop changing.
+
+## aggregates - keyed cross-entity totals
+
+```yaml
+aggregates:
+  - name: onHand
+    of: StockMovement           # the source rows
+    op: sum                     # sum (default) | count
+    sum: quantity               # the summed field
+    by: [Product, Store]        # the grouping keys (to-one relations of BOTH source and target)
+    into: ProductAvailability   # the target entity, keyed by the same relations
+    field: onHand               # the target field holding the total
+```
+
+Where `rollups` write a total onto the parent of a composition (one key, the child's own parent
+relation), an aggregate is keyed by SEVERAL relations and lands in its own entity, so the total is a
+real row other records can reference and pickers can point at: on-hand per product and store, open
+exposure per customer, remaining allowance per employee and year.
+
+Emits three `gen/events/<module>/<Name>AggregateOn{Create,Update,Delete}.java` handlers on the
+source's topics. Each upserts the target row for the incoming row's key-tuple and recomputes the
+field from every source row sharing it (idempotent, self-healing), then writes ONLY the aggregate
+column through the target repository's `updateDerived` - so a concurrent edit to another column of
+the target row is never reverted. A source row with any grouping key null is ignored.
+
+Eventually consistent, not transactionally exact. Editing a grouping key recomputes the tuple the
+row moved INTO; recomputing the tuple it left is a known limitation (append-only ledgers, the
+primary use, are unaffected).
+
+## posts - derived rows on an event
+
+```yaml
+posts:
+  - name: goodsReceiptLedger
+    event: POSTED               # a status value of the source, or `create`
+    forEach: items              # the composition child to iterate (omit for one row per record)
+    into: StockMovement         # the target entity (local or cross-model)
+    idempotentBy: GoodsReceipt  # the target's back-reference FK to the source
+    set:
+      Date:         Receipt.Date
+      Store:        Receipt.Store
+      Product:      item.Product
+      Quantity:     item.Quantity
+      Direction:    1
+      GoodsReceipt: Receipt.Id
+```
+
+A `set` value is a constant, `<Source>.<field>`, `item.<field>`, or a `Calc` expression over those
+(`-item.Quantity` for a sign flip). Several entries under one event emit several rows per item: a
+stock transfer posts an OUT and an IN movement from one document.
+
+Emits a `MessageHandler` on the source's `-transitioned` topic (or the create topic for
+`event: create`) that re-loads the source, skips when target rows already carry the
+`idempotentBy` back-reference, and writes each row through the target repository - so the target's
+own numbering, `checks:` and derived fields fire. The declarative form of the hand-written
+document-to-ledger delegate; contrast `generates`, which creates ONE document from a user action.
 
 ## settlements - payment allocation
 

--- a/docs/help/intent/glue.md
+++ b/docs/help/intent/glue.md
@@ -132,6 +132,38 @@ rollups:
       status: Status, statusWhenFull: 7, statusWhenPartial: 6 }
 ```
 
+## aggregates
+
+A total over one entity's rows grouped by SEVERAL to-one relations, materialised into its own
+entity keyed by the same relations (on-hand per product and store, exposure per customer):
+
+```yaml
+aggregates:
+  - { name: onHand, of: StockMovement, op: sum, sum: quantity,
+      by: [Product, Store], into: ProductAvailability, field: onHand }
+```
+
+Three handlers per aggregate (source create / update / delete) upsert the target row for the
+incoming row's key-tuple and recompute from every source row sharing it. The write is targeted
+(`updateDerived`), so only the aggregate column is persisted. Unlike `rollups`, the total lives in
+a referenceable entity rather than on a composition parent. See the
+[DSL reference](/help/intent/dsl-reference).
+
+## posts
+
+Derived rows into a ledger on a document status event, mapped from the document and its items,
+idempotent by a declared back-reference:
+
+```yaml
+posts:
+  - { name: goodsReceiptLedger, event: POSTED, forEach: items, into: StockMovement,
+      idempotentBy: GoodsReceipt, set: { Product: item.Product, Quantity: item.Quantity } }
+```
+
+The generated handler listens on the source's `-transitioned` topic, skips when rows already
+back-reference the source, and writes through the target repository so its numbering and checks
+still fire.
+
 ## Lifecycle triggers
 
 A process `trigger` (start a process on an entity event) is the original glue and is documented with [processes](/help/intent/intent-file#processes), including the configurable `businessKey` and `businessKeyStrategy: timestamp`. Decision **resolvers** (load a related entity's field at a gateway) are also glue, emitted into `<intent>.glue`.


### PR DESCRIPTION
Three constructs are implemented in the engine but were absent from `/help/intent/` until now. Per the dual-site directive this is the platform half; the vendor-neutral half is IntentFile/intent-specification#1 (proposed specification 1.1) and IntentFile/intentfile.github.io#1.

| Construct | Page | Notes |
| --- | --- | --- |
| **`aggregates`** | dsl-reference + glue | a total over one entity's rows grouped by SEVERAL to-one relations, materialised into its own entity. Documents the three generated handlers, the keyed upsert, the targeted `updateDerived` write, and the key-change limitation. |
| **`checks: kind: guard`** | dsl-reference | the precondition over such a total, with the three outcomes and the optional config gate. |
| **`posts`** | dsl-reference + glue | derived ledger rows on a document event, idempotent by a declared back-reference. Contrasted with `generates`. |

Two behaviours worth documenting precisely, because both are easy to assume wrongly:

- the guard recomputes the total **synchronously from the guarded entity's own rows**, not from the materialised aggregate target, so it cannot race the aggregate handler. Guard and aggregate are two independent computations of the same total and the guard is the authoritative one.
- **`outcome: task` stamps a boolean; it does not create or route to a task.** A process `decision` reads the marker and routes the record.

House style respected: no em/en dashes, absolute cross-links, `npm run docs:build` clean.
