### PR TITLE
docs(intent): a moved aggregate grouping key repairs both tuples

### DIFF
--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -545,9 +545,17 @@ field from every source row sharing it (idempotent, self-healing), then writes O
 column through the target repository's `updateDerived` - so a concurrent edit to another column of
 the target row is never reverted. A source row with any grouping key null is ignored.
 
-Eventually consistent, not transactionally exact. Editing a grouping key recomputes the tuple the
-row moved INTO; recomputing the tuple it left is a known limitation (append-only ledgers, the
-primary use, are unaffected).
+Eventually consistent, not transactionally exact.
+
+Editing a grouping key MOVES the row between tuples and both sides are repaired. The tuple it moved
+into is recomputed off the `-updated` event; for the tuple it LEFT the generated DAO re-reads the row
+before the write, compares every grouping key, and - only when one actually moved - publishes the
+PREVIOUS row on `<project>-<perspective>-<Entity>-rekeyed`, which a fourth handler
+(`<Name>AggregateOnRekey`) recomputes. Only aggregate handlers listen on that topic, so no roll-up,
+notification or integration sees a phantom event. A tuple whose last contributing row leaves keeps
+its target row with a zero total. A grouping key changed through a TARGETED write
+(`updateProperty` / `updateProperties`, e.g. a workflow setter) moves no tuple, because those paths
+raise no entity event at all.
 
 ## posts - derived rows on an event
 

--- a/docs/help/intent/glue.md
+++ b/docs/help/intent/glue.md
@@ -143,8 +143,10 @@ aggregates:
       by: [Product, Store], into: ProductAvailability, field: onHand }
 ```
 
-Three handlers per aggregate (source create / update / delete) upsert the target row for the
-incoming row's key-tuple and recompute from every source row sharing it. The write is targeted
+Four handlers per aggregate (source create / update / delete, plus rekey) upsert the target row for
+the incoming row's key-tuple and recompute from every source row sharing it. The rekey handler
+receives the PREVIOUS row on a dedicated `-rekeyed` topic, published by the DAO only when a grouping
+key actually moved, and repairs the tuple the row left behind. The write is targeted
 (`updateDerived`), so only the aggregate column is persisted. Unlike `rollups`, the total lives in
 a referenceable entity rather than on a composition parent. See the
 [DSL reference](/help/intent/dsl-reference).


### PR DESCRIPTION
Follows #151. The `aggregates` entry documented the old-tuple recompute as a known limitation; it is implemented (eclipse-dirigible/dirigible#6419), so the docs now describe the mechanism instead of the gap.

- **dsl-reference**: the generated DAO re-reads the row before the write, compares every grouping key, and publishes the PREVIOUS row on `<project>-<perspective>-<Entity>-rekeyed` only when a key actually moved; a fourth handler (`<Name>AggregateOnRekey`) recomputes the tuple the row left.
- **glue**: four handlers per aggregate rather than three.

Three things stated because each is easy to assume wrongly: only aggregate handlers subscribe to the rekey topic (no roll-up or notification sees a phantom event), a tuple whose last contributing row leaves keeps a zero total rather than disappearing, and a grouping key changed through a targeted write moves no tuple because those paths raise no entity event at all.

Neutral half updated in the same effort: IntentFile/intent-specification#1 now specifies the rule (it was under *Planned*) and IntentFile/intentfile.github.io#1 renders it.

No em dashes; build clean.
