### PR TITLE
docs(intent): a roll-up parent may live in another model

### DIFF
--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -521,6 +521,15 @@ rollups:
 Roll-ups compose transitively across a multi-level composition (leaf edit → mid total → top
 total); recomputation stops when values stop changing.
 
+The parent may live in ANOTHER model: when `via` is a cross-model relation the child stays local (it
+owns the event the handler binds to) and the parent's package + perspective are resolved from the
+owner's `.model`, so the generated handler imports `gen.<owner>.data.<perspective>.<Parent>Repository`
+and writes through it. The relation's model must be declared in `uses:`; the parent field is checked
+against the owner's model at generation time, and a roll-up that cannot be resolved (undeclared model,
+unknown field) is surfaced in the generate response's issues instead of being dropped silently.
+`capacity` / `balance` / `status` stay local-only - they read the parent's own limit and status seeds
+and stamp the capacity guard on the child.
+
 ## aggregates - keyed cross-entity totals
 
 ```yaml

--- a/docs/help/intent/glue.md
+++ b/docs/help/intent/glue.md
@@ -132,6 +132,12 @@ rollups:
       status: Status, statusWhenFull: 7, statusWhenPartial: 6 }
 ```
 
+
+The parent may be owned by another model: with a cross-model `via` the handler resolves the parent's
+package and perspective from the owner's `.model` and writes through the owner's repository. The
+model must be declared in `uses:`, and an unresolvable roll-up is surfaced in the generate
+response's issues rather than dropped.
+
 ## aggregates
 
 A total over one entity's rows grouped by SEVERAL to-one relations, materialised into its own


### PR DESCRIPTION
Follows #151 and #152. Cross-model roll-ups were impossible until eclipse-dirigible/dirigible#6420: the parser rejected them because the parent entity is not in the local document, so the canonical case (an actual-hours total kept on a project another model owns) had no declarative form.

- **dsl-reference**: the child stays local because it owns the event the handler binds to; the parent's package and perspective resolve from the owner's `.model`, so the handler imports `gen.<owner>.data.<perspective>.<Parent>Repository` and writes through it.
- **glue**: the same note on the roll-ups entry.

Requirements and limits documented, since each one is load-bearing:

- the relation's model must be declared in `uses:`;
- the parent field is checked against the **owner's** model at generation time, not the local document;
- a roll-up that cannot be resolved (undeclared model, unknown field) is surfaced in the generate response's issues rather than dropped silently - the same treatment cross-model notify recipients got in #6391;
- `capacity` / `balance` / `status` stay **local-only**, because they read the parent's own limit and status seeds and stamp the capacity guard on the child.

Neutral half updated in the same effort: IntentFile/intent-specification#1 and IntentFile/intentfile.github.io#1.

No em dashes; build clean.
