### PR TITLE
docs(intent): send a document by e-mail - the notify block + attach: print (#6356)

### DIFF
--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -38,6 +38,7 @@ complete worked example.
 | [`widgets`](#widgets-custom-dashboard-tiles) | custom KPI / embedded-page dashboard tiles |
 | [`seeds`](#seeds-initial-data) | initial data, CSV-backed sets, translations |
 | [`notifications`](#notifications-email-on-change) | email on create/update/delete |
+| [the notify block / `attach: print`](/help/intent/glue#the-notify-block-and-attach-print-sending-the-document-itself) | send a message about a record - with the record's own document attached - from a process step, a transition or a schedule |
 | [`schedules`](#schedules-cron) | cron: notify or generate records per matching row |
 | [`integrations`](#integrations-outbound-http) | outbound HTTP on a data change |
 | [`inbound`](#inbound-webhooks) | webhook that creates records |
@@ -447,7 +448,16 @@ transitions:
     when: "Paid == 0"             # optional guard: <Field> ==|!= <number>
     label: Void
     icon: ban
+    notify:                       # optional: mail the counterparty after the flip commits
+      to: Customer.email          # (fail-soft - a mail problem cannot fail the flip)
+      subject: "Invoice {number} was voided"
+      body: "The invoice has been cancelled."
+      attach: print               # optionally with the document itself attached
 ```
+
+The `notify:` block is the same shape a notification or a schedule uses, and `attach: print` mails the
+record's own rendered document - see
+[the notify block](/help/intent/glue#the-notify-block-and-attach-print-sending-the-document-itself).
 
 ## postings - source-document to ledger
 

--- a/docs/help/intent/glue.md
+++ b/docs/help/intent/glue.md
@@ -43,6 +43,50 @@ notifications:
 
 Generates a `gen/events/<Name>Notification.java` `@Listener` using `sdk.mail.Mail`, bound to the entity's create / `-updated` / `-deleted` topic. `to` and `{placeholder}` resolve a literal, a direct field, or a **one-hop `relation.field`** of a to-one relation (the listener loads the related entity once by FK id). `when:` supports a single `field ==|!= literal` guard. Multi-hop paths (`a.b.c`) are the remaining gap; the parser rejects them with a clear message.
 
+## The notify block - and `attach: print`, sending the document itself
+
+`to` / `subject` / `body` is one reusable **notify block**, not a shape peculiar to `notifications`. The same block is authored at every place an intent can act on a record:
+
+| Where | The record it is about | Generated as |
+| --- | --- | --- |
+| `notifications[]` | the event record | `<Name>Notification.java` (`@Listener`) |
+| `schedules[].notify` | each matched row | `<Name>Job.java` (`@Scheduled`) |
+| `transitions[].notify` | the transitioned record | inside `<Name>Transition.java`, after the flip |
+| a `serviceTask`'s `args.notify` | the process's trigger record | `<Process><Step>Send.java`, a `JavaDelegate` the BPMN binds |
+
+Add **`attach: print`** and the message carries the record's **own document**: the generated `<Entity>PrintFeeder` assembles the `{document, items}` payload through the repositories and `sdk.print.Print` renders it to PDF server-side - the same two steps the snapshot delegate takes - and the result rides along as an `application/pdf` part. This is the declarative form of the most common outbound action a business document has: the invoice to its customer, the payslip to its employee, a dunning reminder carrying the invoice it is about.
+
+```yaml
+    notify:
+      to: Customer.email                 # literal / direct field / one-hop relation.field
+      subject: "Invoice {number}"        # {field} and {relation.field} interpolation
+      body: "Dear {Customer.name}, please find invoice {number} attached."
+      attach: print                      # render THIS record's .print template and attach it
+      language: bg                       # optional print-template language (default en)
+```
+
+`attach`'s only value is `print`, and the entity must be a **document** (a header with a line-items child) - that is what has a `.print` template and a generated feeder to fill it. Attaching the print of a plain entity is a parse-time error, not a silent plain-text mail. The attachment is named after the document's `number:` field when it has one (`INV0000042.pdf`), else `<Entity> <id>.pdf`. The sender address comes from `DIRIGIBLE_MAIL_SENDER`; delivery uses the platform's per-tenant mail configuration.
+
+::: tip Failure semantics, per call site
+A recipient that resolves to no address is a logged **no-op** - a record with nobody to mail must not stall a flow. A `transitions[].notify` is **fail-soft**: the status flip is the endpoint's contract and has already committed, so an SMTP problem is logged and the transition still returns success. A sending `serviceTask`, whose whole purpose *is* the message, fails the task instead, so the process engine's retry applies.
+:::
+
+A sending `serviceTask` stands alone: `notify` cannot be combined with `setField` / `setRelationField` / `call` / `delegate` on the same step - give the send its own step and route to it with `next`.
+
+```yaml
+processes:
+  - name: InvoiceIssue
+    trigger: { onCreate: Invoice }
+    steps:
+      - { name: issue, kind: userTask, args: { assignee: issuer, setRelationField: Status, value: 3, next: mailIt } }
+      - name: mailIt
+        kind: serviceTask
+        args:
+          notify: { to: Customer.email, subject: "Invoice {number}", body: "Attached.", attach: print }
+          next: end
+      - { name: end, kind: end }
+```
+
 ## schedules
 
 Cron reminders / cleanups - query an entity and act per matching row.
@@ -196,6 +240,7 @@ The event-then-action glue above, plus the data-flow glue documented in the
 | Lifecycle triggers (process start, `when` guard, business key + timestamp strategy) | implemented |
 | Decision / form resolvers (`relation.field` at a gateway or on a task form) | implemented |
 | Notifications (email; literal / field / one-hop relation; `when`) | implemented |
+| Send a document by e-mail (a notify block with `attach: print`, on a process step / transition / schedule) | implemented |
 | Schedules (cron to typed-`Criteria` query; per-row `notify` or `generate`) | implemented |
 | Integrations (event to `HttpClient`) | implemented |
 | Inbound webhooks (`@Controller` ingest to entity) | implemented |
@@ -208,7 +253,7 @@ The event-then-action glue above, plus the data-flow glue documented in the
 | Waits (`wait` step - park on an entity event, correlate by `ProcessId`) | implemented |
 | Boundary timers (userTask `timeout:` reminder / `expire:` date-driven withdrawal) | implemented |
 | Standard per-document PDF print templates | implemented (see [Printing](/help/intent/printing)) |
-| Event-driven document generation (produce a PDF on an event) | planned |
+| Event-driven document generation (produce a PDF on an event) | implemented - mailed by `attach: print`, stored by `function: Snapshot` |
 | Status lifecycle / declarative state machine | planned |
 | Audit history (shadow `<Entity>History` entity; audit *columns* via `audit: true` ship today) | planned |
 | Arbitrary resolver-path task assignment (beyond `assignee: personal`) | planned |


### PR DESCRIPTION
Documents the feature added in eclipse-dirigible/dirigible#6435 (closes eclipse-dirigible/dirigible#6356).

**Glue page** gains *The notify block - and `attach: print`, sending the document itself*:

- `to` / `subject` / `body` is one reusable block, not a shape peculiar to `notifications` - a table shows the four call sites (`notifications[]`, `schedules[].notify`, `transitions[].notify`, a `serviceTask`'s `args.notify`) and the class each generates (`<Name>Notification.java`, `<Name>Job.java`, inside `<Name>Transition.java`, `<Process><Step>Send.java`).
- `attach: print` reuses the generated `<Entity>PrintFeeder` + `sdk.print.Print` (the snapshot delegate's two steps) and rides along as an `application/pdf` part named after the document's `number:`.
- Failure semantics per call site: a recipient that resolves to nothing is a logged no-op, a `transitions[].notify` is fail-soft (the flip already committed), a sending `serviceTask` fails so the engine retries.
- Only a document (header + line-items child) can be attached - a parse-time error otherwise.

Also in this PR: the glue status table lists the feature, the stale *"Event-driven document generation - planned"* row now reflects reality (mailed by `attach: print`, stored by `function: Snapshot`), and the DSL reference's `transitions` example shows the optional `notify` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)