### PR TITLE
docs(intent): number series are tenant configuration - format/scope leave the DSL

### DIFF
--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -75,7 +75,7 @@ entities:
 ```yaml
 - { name: code,  type: string, unique: true, length: 30 }              # UNIQUE constraint
 - { name: uuid,  type: uuid, major: false }                            # auto-filled on create, off the list table
-- { name: Number, type: string, number: { series: SalesInvoice, format: "SI-{seq:06}" } }  # document number
+- { name: Number, type: string, number: { series: Sales Invoice, per: Company, stampOn: create } }  # document number
 - { name: total, type: decimal, precision: 18, scale: 2, readOnly: true }
 - { name: period, type: month }                                        # YYYY-MM month picker
 - { name: sprint, type: week }                                         # YYYY-Www ISO-week picker
@@ -245,38 +245,68 @@ a calculated action - the platform owns a gap-free sequence for you.
 ## number - document numbering
 
 Turns a string field into a platform-numbered document field. The platform owns a **gap-free,
-per-tenant sequence per series**, renders it through the `format`, and stamps the field
-automatically - no hand-written number action or delegate.
+per-tenant sequence per series** and stamps the field automatically - no hand-written number action
+or delegate. The intent declares only a **reference to a series** - never how the number looks.
 
 ```yaml
 # stamped on create (the number exists the moment the record is saved):
-- { name: Number, type: string, number: { series: Proforma, format: "PF{seq:08}", stampOn: create } }
+- { name: Number, type: string, number: { series: Proforma, stampOn: create } }
 
-# stamped at a modeled issue step (a UUID placeholder holds the field until then):
+# partitioned per company, stamped at a modeled issue step (a UUID placeholder holds the field until then):
 - name: Number
   type: string
   number:
-    series: SalesInvoice          # documents sharing a sequence pass the same series
-    format: "SI-{year}-{seq:05}"  # {seq} / {seq:0N} / {series} / scope tokens {year},{<Field>}
-    scope: [year]                 # partitions the counter (and feeds {year}); omit for one continuous sequence
-    stampOn: issue                # create | issue
+    series: Sales Invoice   # documents sharing one legal range pass the same series
+    per: Company            # optional: a to-one relation whose value partitions the sequence
+    stampOn: issue          # create | issue
 ```
 
-- **`series`** (default: the entity name) - the sequence identity. Give several document types
-  (invoice, credit note, debit note) the **same series** to share one running number.
-- **`format`** (default `{series}-{seq:06}`) - `{seq}`, `{seq:0N}` (zero-padded), `{series}`, and
-  scope tokens `{year}` / `{<Field>}`.
-- **`scope`** - `year` and/or sibling field names; partitions the counter and supplies the format's
-  scope tokens. Omit for a single continuous sequence.
+- **`series`** (mandatory) - the sequence identity. Give several document types (invoice, credit
+  note, debit note) the **same series** to share one running number.
+- **`per`** (optional) - a to-one relation of the entity whose value **partitions** the series:
+  each partition value gets its own sequence, prefix and width. The canonical use is
+  `per: Company` - two legal entities in one tenant each owe their own sequential range and must
+  never share a counter. Identical numbers across partitions are correct; the partition only
+  selects which sequence to draw from and never appears in the number. An `EntityStatus` relation
+  cannot partition a series.
 - **`stampOn`** - `create` stamps the real number on insert; `issue` puts a UUID placeholder on the
   field at create and generates a `gen/events/<Entity>NumberStamp` delegate that stamps the real
   number when the process reaches the step wired with `delegate: gen.events.<Entity>NumberStamp`.
   Stamping is **idempotent** - re-issuing after an amend keeps the same number.
 
+### The series is tenant configuration, not model
+
+A number series is a **tenant-level business object**, not a module asset. A number renders as **a
+literal prefix plus the sequence zero-padded to a total width** (`SI00000042`) - there is no token
+grammar, and neither the prefix nor the width is authored in the intent: baking a format into the
+model would force a market that numbers documents differently to fork and regenerate the
+application.
+
+A module declares the series it needs in a **`.numbers` artefact** at the project root - a
+requirement declaration, exactly as `.roles` declares roles (authored by hand, never generated):
+
+```json
+{"series": [{"name": "Sales Invoice", "prefix": "SI", "size": 10}]}
+```
+
+At publish, the `.numbers` synchronizer provisions each declared series **per tenant** when the
+tenant has none yet - an existing series keeps its live counter and whatever shape its
+administrator configured. Two modules may declare the same series only **identically** (a shared
+legal range provisions once); a differing re-declaration fails that artefact loudly, naming both
+modules. Unpublishing a module never removes a series or its counter - allocated ranges are
+business history.
+
+Sequences are **continuous and never auto-reset**. A jurisdiction that restarts numbering each year
+does it by an administrator setting the prefix and the next value (e.g. prefix `2027-`, next `1`,
+in January) in the application shell's **Document Numbering** settings - visible and auditable,
+rather than a hidden reset rule that could mint the same number twice. Allocating from a series no
+`.numbers` artefact declares fails loudly - a document must never carry a number in a shape nobody
+chose.
+
 The field is read-only in the UI, and the create-time UUID placeholder is hidden in document titles
-until the real number is stamped. Counters are visible and adjustable in the application shell's
-**Document Numbering** settings, and are reachable from bespoke code through the Java SDK
-[`DocumentNumbers`](/sdk/numbering/documentnumbers) facade.
+until the real number is stamped. Each series' prefix, total width and next value are configured
+per tenant in the **Document Numbering** settings, and series are reachable from bespoke code
+through the Java SDK [`DocumentNumbers`](/sdk/numbering/documentnumbers) facade.
 
 ## view - calendar, range, slots
 

--- a/docs/sdk/numbering/documentnumbers.md
+++ b/docs/sdk/numbering/documentnumbers.md
@@ -1,6 +1,6 @@
 ---
 title: DocumentNumbers
-description: Allocate the next gap-free document number for a series and render it through a format.
+description: Allocate the next gap-free document number from a declared series.
 ---
 
 # DocumentNumbers
@@ -12,42 +12,28 @@ description: Allocate the next gap-free document number for a series and render 
 - source: [numbering/DocumentNumbers.java](https://github.com/eclipse/dirigible/blob/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/numbering/DocumentNumbers.java)
 :::
 
-Allocates the next gap-free number for a document series and renders it through the series' format. Backed by the platform's per-tenant counter store, so every caller of the same series shares one continuously advancing sequence - hand-written `custom/` code, the intent-generated stamping, and any manual adjustment made through the application shell's **Document Numbering** settings all draw from the same counter.
+Allocates the next gap-free number from a named **series**. The number's SHAPE is deliberately not knowable from application code: a series renders as a **literal prefix plus the sequence zero-padded to a total width** (`SI00000042`), declared once in a module's [`.numbers` artefact](/help/intent/dsl-reference#number-document-numbering) and configurable per tenant in the application shell's **Document Numbering** settings - so one application serves jurisdictions with different numbering conventions without being forked or regenerated. Every caller of the same series - hand-written `custom/` code, the intent-generated stamping, several document types sharing one legal range - draws from the same continuously advancing counter.
 
 ### Key Features
 
 - **Gap-free**: Each allocation advances the counter by one under a row lock; there are no holes and no duplicates, even under concurrent creates.
 - **Per-tenant**: The counter table lives in the tenant's own schema, so numbers are isolated per tenant and portable with the tenant's data.
-- **Scoped**: The optional scope map partitions the counter (e.g. one sequence per year, or per company) and, at the same time, feeds the format's `{year}` / `{<Field>}` tokens.
-- **Formatted**: A small format grammar turns the raw sequence into the printed document number.
-
-### Format grammar
-
-The `format` template is rendered with these tokens:
-
-| Token | Renders |
-| ------ | ------ |
-| `{seq}` | The raw sequence number. |
-| `{seq:0N}` | The sequence zero-padded to `N` digits (e.g. `{seq:06}` -> `000042`). |
-| `{series}` | The series identity. |
-| `{year}` / `{<Field>}` | A value from the scope map (the key matched case-insensitively). |
-
-A `null` or blank format falls back to the default `{series}-{seq:06}`.
+- **Partitioned**: The optional partition value (typically a company id - the intent's `per:` relation) gives each partition its own sequence, prefix and width. Two legal entities in one tenant never share a counter; identical numbers across partitions are correct.
+- **Declared, never invented**: Allocating from a series no `.numbers` artefact declares fails loudly - a document must never carry a number in a shape nobody chose.
+- **Continuous**: Sequences never auto-reset. An annual restart is an administrator setting the prefix and the next value in the Document Numbering settings.
 
 ### Example Usage
 
 ```java
 import org.eclipse.dirigible.sdk.numbering.DocumentNumbers;
-import java.util.Map;
 
-// Unscoped series - one continuous sequence:
-String order = DocumentNumbers.next("SalesOrder", "SO-{seq:06}");
-// -> "SO-000001", then "SO-000002", ...
+// One tenant-wide sequence (the series' shape comes from its declaration / settings):
+String invoice = DocumentNumbers.next("Sales Invoice");
+// -> "SI00000001", then "SI00000002", ...
 
-// Scoped by year - the counter partitions per year and the format prints it:
-String invoice = DocumentNumbers.next("SalesInvoice", "SI-{year}-{seq:05}",
-        Map.of("year", "2026"));
-// -> "SI-2026-00001", then "SI-2026-00002", ...
+// Partitioned per company - each company id owns its own sequence:
+String order = DocumentNumbers.next("Sales Order", String.valueOf(entity.Company));
+// -> company 1: "SO000001", "SO000002", ... ; company 2 independently: "SO000001", ...
 ```
 
 Prefer the declarative `number: { ... }` field in the [intent DSL](/help/intent/dsl-reference#number-document-numbering) - it generates the stamping (on create, or at a modeled issue step) and calls this SDK for you. Reach for `DocumentNumbers` directly only from bespoke logic (a custom `JavaDelegate` or calculated action) that the declarative form does not express.
@@ -56,37 +42,35 @@ Prefer the declarative `number: { ... }` field in the [intent DSL](/help/intent/
 
 ### next()
 
-Allocate and format the next number for a series, partitioned and formatted by the given scope.
+Allocate the next number of a series within a partition.
 
 > ```java
-> public static String next(String series, String format, Map<String, String> scope);
+> public static String next(String series, String partition);
 > ```
 >
 > | Parameter | Type | Description |
 > | ------ | ------ | ------ |
 > | `series` | `String` | The series identity. Documents that must share one sequence pass the same series. |
-> | `format` | `String` | The format template (see the grammar above), or `null`/blank for the default `{series}-{seq:06}`. |
-> | `scope` | `Map<String, String>` | The resolved scope values that partition the counter and feed `{year}` / `{<Field>}` tokens. Use an empty map for an unscoped series. |
+> | `partition` | `String` | The partition value (the `per:` relation's id, e.g. the company id), or `null` when the series is not partitioned. |
 >
 > ::: info Returns
 > - **Type**: `String`
-> - **Description**: The formatted document number.
+> - **Description**: The allocated number, rendered as the series' prefix plus the sequence zero-padded to the series' total width.
 > :::
 
 ### next()
 
-Allocate and format the next number for an unscoped series (scope defaults to empty).
+Allocate the next number of an unpartitioned series.
 
 > ```java
-> public static String next(String series, String format);
+> public static String next(String series);
 > ```
 >
 > | Parameter | Type | Description |
 > | ------ | ------ | ------ |
 > | `series` | `String` | The series identity. |
-> | `format` | `String` | The format template (see the grammar above), or `null`/blank for the default. |
 >
 > ::: info Returns
 > - **Type**: `String`
-> - **Description**: The formatted document number.
+> - **Description**: The allocated number.
 > :::

--- a/docs/sdk/numbering/index.md
+++ b/docs/sdk/numbering/index.md
@@ -1,6 +1,6 @@
 ---
 title: numbering
-description: First-class document numbering - gap-free per-series sequences rendered through a format.
+description: First-class document numbering - gap-free sequences from declared, tenant-configurable series.
 ---
 
 # numbering/index
@@ -12,12 +12,12 @@ description: First-class document numbering - gap-free per-series sequences rend
 - source: [numbering/](https://github.com/eclipse/dirigible/tree/master/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/numbering)
 :::
 
-The `numbering` module allocates the next gap-free number for a document series and renders it through the series' format. It is backed by the platform's per-tenant counter store - the same store the application shell's **Document Numbering** settings manage - so hand-written `custom/` code and the intent-generated stamping share one engine and one sequence per series.
+The `numbering` module allocates the next gap-free number from a declared document-number series - rendered as the series' literal prefix plus the sequence zero-padded to its total width. It is backed by the platform's per-tenant counter store - the same store the application shell's **Document Numbering** settings manage - so hand-written `custom/` code and the intent-generated stamping share one engine and one sequence per series.
 
-Numbering is a first-class concern in business software (invoices, orders, receipts, credit and debit notes), so the platform owns the sequence: allocation is gap-free, the counter lives in the tenant's schema, and the number is formatted from a small grammar. Most applications never call this SDK directly - they declare a `number: { ... }` field in the intent model and the generator wires the stamping. Use the SDK when you need a number from bespoke logic that the declarative form does not cover.
+Numbering is a first-class concern in business software (invoices, orders, receipts, credit and debit notes), so the platform owns the sequence: allocation is gap-free, the counter lives in the tenant's schema, and the shape (prefix + width) is declared by the module's `.numbers` artefact and configured per tenant - never baked into code. Most applications never call this SDK directly - they declare a `number: { ... }` field in the intent model and the generator wires the stamping. Use the SDK when you need a number from bespoke logic that the declarative form does not cover.
 
 The main components of this module are:
-- **DocumentNumbers**: Static `next(series, format[, scope])` - allocate and format the next number.
+- **DocumentNumbers**: Static `next(series[, partition])` - allocate the next number of a series (optionally within a partition, e.g. per company).
 
 ## Classes
 


### PR DESCRIPTION
Documents the redesigned first-class document numbering:

- `number:` now references a **series by name only** (`series` mandatory, optional `per:` partition relation, `stampOn`); the `format` and `scope` keys are removed and rejected at parse
- a number renders as a **literal prefix + the sequence zero-padded to a total width** - no token grammar
- the series' shape is declared per module in an authored **`.numbers` artefact** (provision-if-absent per tenant, identical cross-module re-declarations shared, differing ones fail loudly, delete never touches a counter) and configured per tenant in the shell's **Document Numbering** settings
- sequences are **continuous, never auto-reset** - an annual restart is prefix + next set by an administrator
- SDK page updated to the new `DocumentNumbers.next(series[, partition])` signature

Matches the platform PR on `eclipse-dirigible/dirigible` (branch `feat/numbering-series-artefact`).