### PR TITLE
docs(intent): live print + snapshot/notify render language; .numbers partition sources

### DIFF
--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -296,6 +296,23 @@ legal range provisions once); a differing re-declaration fails that artefact lou
 modules. Unpublishing a module never removes a series or its counter - allocated ranges are
 business history.
 
+A **partitioned** series (`per:`) may additionally declare its **partition source** - the physical
+table its partition values come from, with the key and display-label columns (authored physical
+coordinates, exactly like a `.csvim`'s table and columns):
+
+```json
+{"series": [{"name": "Sales Invoice", "prefix": "SI", "size": 10,
+             "partitions": {"table": "CRM_COMPANY", "key": "COMPANY_ID", "label": "COMPANY_NAME"}}]}
+```
+
+With a partition source declared, the **Document Numbering** settings label each partition row by
+the entity's display name ("Sales Invoice — ACME Ltd." instead of a raw id) and list a row for
+**every** partition value before its first allocation - so an operator seeds a company's starting
+number before its first document is issued; saving such a row provisions it exactly as the first
+allocation would have (the base row's shape, then the edit). The identifiers must be plain SQL
+names (validated at parse), and a differing cross-module re-declaration fails the artefact just
+like a differing shape.
+
 Sequences are **continuous and never auto-reset**. A jurisdiction that restarts numbering each year
 does it by an administrator setting the prefix and the next value (e.g. prefix `2027-`, next `1`,
 in January) in the application shell's **Document Numbering** settings - visible and auditable,

--- a/docs/help/intent/glue.md
+++ b/docs/help/intent/glue.md
@@ -62,10 +62,11 @@ Add **`attach: print`** and the message carries the record's **own document**: t
       subject: "Invoice {number}"        # {field} and {relation.field} interpolation
       body: "Dear {Customer.name}, please find invoice {number} attached."
       attach: print                      # render THIS record's .print template and attach it
-      language: bg                       # optional print-template language (default en)
+      language: bg                       # optional FIXED print-template language
+      # or per record: languageFrom: Customer.locale  (a one-hop relation.field holding the code)
 ```
 
-`attach`'s only value is `print`, and the entity must be a **document** (a header with a line-items child) - that is what has a `.print` template and a generated feeder to fill it. Attaching the print of a plain entity is a parse-time error, not a silent plain-text mail. The attachment is named after the document's `number:` field when it has one (`INV0000042.pdf`), else `<Entity> <id>.pdf`. The sender address comes from `DIRIGIBLE_MAIL_SENDER`; delivery uses the platform's per-tenant mail configuration.
+`attach`'s only value is `print`, and the entity must be a **document** (a header with a line-items child) - that is what has a `.print` template and a generated feeder to fill it. Attaching the print of a plain entity is a parse-time error, not a silent plain-text mail. The attachment is named after the document's `number:` field when it has one (`INV0000042.pdf`), else `<Entity> <id>.pdf`. The **render language**: `language:` fixes the print-template language; `languageFrom: <relation>.<field>` reads it per record off a one-hop to-one path (the customer decides the language their invoice arrives in) - the two are mutually exclusive. Absent both, the render uses the first entry of the tenant's application language set (`DIRIGIBLE_APPLICATION_LANGUAGES`) at send time; a blank `languageFrom` value falls back the same way. The sender address comes from `DIRIGIBLE_MAIL_SENDER`; delivery uses the platform's per-tenant mail configuration.
 
 ::: tip Failure semantics, per call site
 A recipient that resolves to no address is a logged **no-op** - a record with nobody to mail must not stall a flow. A `transitions[].notify` is **fail-soft**: the status flip is the endpoint's contract and has already committed, so an SMTP problem is logged and the transition still returns success. A sending `serviceTask`, whose whole purpose *is* the message, fails the task instead, so the process engine's retry applies.

--- a/docs/help/intent/printing.md
+++ b/docs/help/intent/printing.md
@@ -105,7 +105,24 @@ doc/Templates/SalesInvoice/Print/en/standard.print
 doc/Templates/SalesInvoice/Print/bg/standard.print
 ```
 
-When several languages exist, the Print button asks which to use; otherwise it prints the only one. The default follows the user's Region &amp; Language setting.
+When several languages exist, the Print button asks which to use; otherwise it prints the only one. The default follows the user's Region &amp; Language setting. The Print button always renders **live** - current master data, the language just chosen. The immutable copy of an issued document is a separate, first-class surface: see below.
+
+## The issued copy and its language
+
+A document may declare a `function: Snapshot` composition child - an **immutable, versioned PDF copy** minted by the process (typically right after Issue) and served by a read-only files panel on the document page, with a per-version **Open** and **Download**. Printing and the stored copy answer different questions: Print renders the document as it is *now*; the snapshot panel serves the document as it was *issued* - both stay one click apart on the same page.
+
+The language a copy is **minted** in is a knob on the snapshot child:
+
+```yaml
+- name: SalesInvoiceCopy
+  function: Snapshot
+  languageFrom: customer.language      # per record - the customer decides the invoice's language
+  # or: language: bg                   # fixed
+  relations:
+    - { name: salesInvoice, kind: manyToOne, to: SalesInvoice, composition: true }
+```
+
+`languageFrom` is a one-hop path on the document master - a to-one relation and a string field of its target holding the language code; it works across models like any other cross-model reference. `language` fixes the code; the two are mutually exclusive. Absent both (or when the resolved value is blank), the mint uses the first entry of the tenant's application language set (`DIRIGIBLE_APPLICATION_LANGUAGES`) - so a tenant configured `bg,en` mints Bulgarian copies with no intent change, provided a `bg` template exists.
 
 ## Printing at runtime
 


### PR DESCRIPTION
Documents the platform changes from eclipse-dirigible/dirigible#6492 (print always renders live; `language:`/`languageFrom:` on `function: Snapshot` children and on notify `attach: print`, with the tenant-language fallback) and eclipse-dirigible/dirigible#6507 (`.numbers` `partitions` block - labeled partition rows + seeding counters before first use in the Document Numbering settings).

- `printing.md`: the Print button always renders live; new "The issued copy and its language" section (Snapshot child, per-version Open/Download, `language`/`languageFrom`, tenant fallback).
- `glue.md`: the notify block's render-language knobs and fallback semantics.
- `dsl-reference.md`: the `.numbers` partition-source declaration and what the settings page does with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)