### PR TITLE
docs(intent): cross-model schedule source (model: on schedules + forEach)

### DIFF
--- a/docs/help/intent/dsl-reference.md
+++ b/docs/help/intent/dsl-reference.md
@@ -749,7 +749,7 @@ Per matching row, exactly one of `notify` or `generate`:
 schedules:
   - name: monthlyTimesheets
     cron: "0 0 1 1 * ?"
-    entity: Employee                          # the schedule's SOURCE must be local
+    entity: Employee                          # SOURCE - local, or cross-model via `model:`
     where:
       - { field: status, op: eq, value: ACTIVE }
     generate:
@@ -757,6 +757,8 @@ schedules:
       map: { Employee: id }
       defaults: { Period: now }
 ```
+
+The source may live in another model via `model: <uses alias>` (generate action only; a `forEach` collection may carry its own `model:` too) - see [glue › cross-model source](/help/intent/glue#cross-model-source-model).
 
 ## integrations - outbound HTTP
 
@@ -799,8 +801,8 @@ Reports, Settings including Region & Language).
   message/file events. Today's implemented glue: triggers, decision/form resolvers, notifications,
   schedules (notify + generate), integrations, inbound webhooks, rollups, settlements, expansions,
   generates, transitions, postings, numbering (the `number:{stampOn:issue}` stamp delegate).
-- **Cross-model schedule source** - a schedule's `entity` must be local (the generate target may
-  be cross-model).
+- ~~Cross-model schedule source~~ - landed: a schedule's `entity` (and a `forEach` collection) may
+  live in another model via `model: <uses alias>` (generate action only).
 - ~~`generates` completion hook~~ - landed: `sourceStatus` flips the source's status after the
   target is created.
 - ~~Embedded calendar panel for a dependent composition child~~ - landed: a calendar-view

--- a/docs/help/intent/glue.md
+++ b/docs/help/intent/glue.md
@@ -153,6 +153,38 @@ schedules:
           dayField: day
 ```
 
+### Cross-model source (`model:`)
+
+The source `entity` is a local entity by default. Add `model: <uses alias>` to read the source from another (owner) model, so the schedule can live with the module that owns the CREATED rows instead of being forced into the source's module with a back-reference. The generated `JobHandler` imports the owner's `gen.<owner>.data...` classes and only READS them (a schedule never writes its source). A `forEach` collection may likewise be cross-model with its own `model:` alias. Both aliases must be declared under `uses:`.
+
+```yaml
+uses:
+  - { model: projects }
+
+schedules:
+  - name: monthlyProjectTimesheets
+    cron: "0 0 2 1 * ?"
+    entity: Project
+    model: projects                    # the source Project lives in the projects model
+    where:
+      - { field: Status, op: eq, value: 2 }
+    generate:
+      to: ProjectTimesheet             # LOCAL - owned by this model, no uses: needed
+      map: { Project: id, Customer: Customer }
+      defaults: { Period: now }
+      children:
+        - to: EmployeeTimesheet
+          parent: ProjectTimesheet
+          forEach:
+            entity: EmployeeProjectAssignment
+            model: projects            # the forEach collection is also cross-model
+            match: { Project: id }
+          map: { Employee: Employee }
+```
+
+- **`generate` only.** A cross-model source with a `notify` action is rejected at parse - notify needs the source's relation metadata, which only a local entity carries. Keep such a schedule in the source's model, or drop `model:`.
+- **Validation split** (the same one relations use): that `model:` names a declared `uses:` alias is checked at parse; the source entity's existence and the `where` / `map` / `match` field references are checked at **generation** against the owner's `.model` (generate the owner model first, or install/publish its prebuilt module). A missing owner or a mistyped field drops that schedule with a warning in the generate response - it never emits a job that cannot compile.
+
 ## integrations
 
 Tell another system on an event (outbound HTTP).


### PR DESCRIPTION
Documents `model: <uses alias>` on a schedule's source `entity` (and on a `forEach` collection): the schedule reads a source owned by another model, so it can live with the module that owns the CREATED rows. Covers the generate-only limitation, the read-only source, and the parse-vs-generation validation split. Updates the glue reference, the DSL reference, and moves the item out of 'Planned'.