### PR TITLE
docs(documents): dynamic folder access control + the ALL-to-ANY role upgrade note

### DIFF
--- a/docs/help/ide/perspectives/documents.md
+++ b/docs/help/ide/perspectives/documents.md
@@ -27,6 +27,29 @@ The active backend is selected by the deployed engine:
 
 When multi-tenancy is enabled (`DIRIGIBLE_MULTI_TENANT_MODE=true`, the default), the documents tree is scoped to the calling tenant. Each tenant sees only its own files.
 
+## Access control
+
+Folder permissions are granted at runtime, per path and per role, from the **Manage access** dialog - available both in this perspective and in the Documents section of the application shell. Grants are stored per tenant and take effect on the next request.
+
+The rules that decide whether a caller may read or write a path:
+
+- **A path with no rules is open** to anyone who can reach Documents. The store is not deny-by-default; a rule is what restricts it.
+- **Rules are inherited** - a rule on `/reports` covers everything beneath it.
+- **The most specific path decides.** Only the rules of the deepest folder that has any are considered, so a restricted parent can have one child opened up again.
+- **Roles are alternatives** - holding *any* granted role is enough.
+- **Writing implies reading.** A caller who may not read a path may not write it either.
+
+System activity is never subject to these rules: content seeding, scheduled jobs, workflow delegates and message listeners act as the platform rather than as a user, and have no roles to check. Enforcement can be switched off entirely with `DIRIGIBLE_CMS_ROLES_ENABLED=false`, which - like the enforcement itself - is configurable per tenant from the shell's Settings.
+
+::: warning Upgrade note - role matching changed from ALL to ANY
+
+Before this change the folder listing required a caller to hold **every** role listed for a path, while the CMIS access check required only **one** of them - two mechanisms answering the same question differently. There is now a single rule: **any** granted role suffices, matching how HTTP `.access` constraints have always behaved.
+
+A path that lists more than one role therefore becomes **more permissive** than it was in the listing: the second role now reads as an alternative rather than an additional requirement. If a deployment authored multi-role folder rules expecting the all-of behaviour, review them after upgrading.
+
+Rules with a single role per path are unaffected, as is any installation that never authored folder rules - which, since no user interface existed for setting them before, is the usual case.
+:::
+
 ## Programmatic access
 
 The same operations are available from user code:


### PR DESCRIPTION
Documents the runtime folder access control on the Documents help page, and — the reason for filing this now — states the behaviour change for anyone upgrading.

## What is documented

The **Manage access** dialog (this perspective and the application shell's Documents section) and the rules that decide a path:

- a path with no rules is **open** — the store is not deny-by-default;
- rules are **inherited** by everything beneath a path;
- the **most specific path decides**, so a restricted parent can have one child opened again;
- roles are **alternatives** — any granted role suffices;
- **writing implies reading**.

Plus the system contexts that are never subject to them (seeding, jobs, workflow delegates, listeners — they act as the platform and have no roles), and the per-tenant `DIRIGIBLE_CMS_ROLES_ENABLED` kill switch.

## The upgrade note

Two mechanisms used to answer "may this caller read this path" differently: the folder listing demanded **every** listed role, the CMIS access check demanded **one**. They are now a single rule — **any** granted role suffices, matching HTTP `.access`.

So a path listing more than one role becomes **more permissive** than the listing was: the second role reads as an alternative rather than an additional requirement. Worth a review by anyone who authored multi-role folder rules; single-role paths are unaffected, and installations that authored no folder rules at all — the usual case, since no user interface existed for setting them — see no change.

Uses the site's `::: warning` container (the page had no admonition before; MkDocs `!!!` syntax would not render here).

Pairs with the platform change in eclipse-dirigible/dirigible#6566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
